### PR TITLE
Implements low-level subscriptions in thegraph connectors

### DIFF
--- a/examples/organization-viewer-cli/src/index.ts
+++ b/examples/organization-viewer-cli/src/index.ts
@@ -11,25 +11,26 @@ const network = 'mainnet'
 const DAO_SUBGRAPH_URL =
   'https://api.thegraph.com/subgraphs/name/aragon/aragon-mainnet-staging'
 const ALL_VOTING_SUBGRAPH_URL =
-  'https://api.thegraph.com/subgraphs/name/ajsantander/aragon-voting'
+  'https://api.thegraph.com/subgraphs/name/ajsantander/aragon-voting-rinkeby'
 const ALL_TOKEN_MANAGER_SUBGRAPH_URL =
   'https://api.thegraph.com/subgraphs/name/ajsantander/aragon-token-mainnet'
 
 const ORG_ADDRESS = '0x0c188b183ff758500d1d18b432313d10e9f6b8a4'
-const VOTING_APP_ADDRESS = '0x8012a3f8632870e64994751f7e0a6da2a287eda3'
+const VOTING_APP_ADDRESS = '0xc73e86aab9d232495399d62fc80a36ae52952b81'
 const TOKENS_APP_ADDRESS = '0x0021b622f112f6328886e8aa757a16952c94b130'
 
 async function main() {
-  const org = await initAndGetOrg()
+  // const org = await initAndGetOrg()
 
-  await inspectOrg(org)
+  // await inspectOrg(org)
 
-  await trySimplePath(org)
+  // await trySimplePath(org)
 
-  await inspectVotingHighLevel(VOTING_APP_ADDRESS)
-  await inspectVotingLowLevel(VOTING_APP_ADDRESS)
+  // await inspectVotingHighLevel(VOTING_APP_ADDRESS)
+  // await inspectVotingLowLevel(VOTING_APP_ADDRESS)
+  await inspectVotingLowLevelSubscription(VOTING_APP_ADDRESS)
 
-  await inspectTokenManager(TOKENS_APP_ADDRESS)
+  // await inspectTokenManager(TOKENS_APP_ADDRESS)
 }
 
 async function initAndGetOrg(): Promise<Organization> {
@@ -174,6 +175,38 @@ async function inspectVotingLowLevel(appAddress: string): Promise<void> {
   `)
 
   console.log(JSON.stringify(results.data, null, 2))
+}
+
+async function inspectVotingLowLevelSubscription(appAddress: string): Promise<void> {
+  console.log('\nLow-level inspection of a voting app using subscriptions:')
+  const wrapper = new GraphQLWrapper(ALL_VOTING_SUBGRAPH_URL)
+
+  const subscription = wrapper.subscribeToQuery(
+    gql`
+      subscription {
+        votes(where:{
+          appAddress: "${appAddress}"
+        }) {
+          id
+          metadata
+          creator
+        }
+      }
+    `,
+    {},
+    (results: any) => {
+      console.log(JSON.stringify(results.data, null, 2))
+    }
+  )
+
+  // Keep the program running
+  await new Promise(resolve => {
+    setTimeout(() => {
+      resolve()
+
+      subscription.unsubscribe()
+    }, 1000000000)
+  })
 }
 
 main()

--- a/examples/organization-viewer-cli/src/index.ts
+++ b/examples/organization-viewer-cli/src/index.ts
@@ -20,17 +20,18 @@ const VOTING_APP_ADDRESS = '0xc73e86aab9d232495399d62fc80a36ae52952b81'
 const TOKENS_APP_ADDRESS = '0x0021b622f112f6328886e8aa757a16952c94b130'
 
 async function main() {
-  // const org = await initAndGetOrg()
+  const org = await initAndGetOrg()
 
-  // await inspectOrg(org)
+  await inspectOrg(org)
 
-  // await trySimplePath(org)
+  await trySimplePath(org)
 
-  // await inspectVotingHighLevel(VOTING_APP_ADDRESS)
-  // await inspectVotingLowLevel(VOTING_APP_ADDRESS)
+  await inspectVotingHighLevel(VOTING_APP_ADDRESS)
+  await inspectVotingLowLevel(VOTING_APP_ADDRESS)
+
+  await inspectTokenManager(TOKENS_APP_ADDRESS)
+
   await inspectVotingLowLevelSubscription(VOTING_APP_ADDRESS)
-
-  // await inspectTokenManager(TOKENS_APP_ADDRESS)
 }
 
 async function initAndGetOrg(): Promise<Organization> {

--- a/packages/connect-thegraph/package.json
+++ b/packages/connect-thegraph/package.json
@@ -21,10 +21,12 @@
   },
   "dependencies": {
     "@aragon/connect-core": "*",
+    "@types/ws": "^7.2.5",
     "@urql/core": "^1.11.7",
     "graphql": "^15.0.0",
     "graphql-tag": "^2.10.3",
-    "isomorphic-unfetch": "^3.0.0"
+    "isomorphic-unfetch": "^3.0.0",
+    "subscriptions-transport-ws": "^0.9.16"
   },
   "description": "Access and interact with Aragon Organizations and their apps.",
   "keywords": [

--- a/packages/connect-thegraph/src/core/GraphQLWrapper.ts
+++ b/packages/connect-thegraph/src/core/GraphQLWrapper.ts
@@ -50,8 +50,15 @@ export default class GraphQLWrapper {
     return pipe(
       this.#client.executeSubscription(request),
       subscribe((result: any) => {
-        console.log(`NEW RESULTS...`)
-        // TODO: parse and describe here
+        if (this.#verbose) {
+          console.log(this.describeQueryResult(result))
+        }
+
+        if (result.error) {
+          throw new Error(
+            `Error performing subscription.${this.describeQueryResult(result)}`
+          )
+        }
 
         callback(result)
       })
@@ -65,7 +72,7 @@ export default class GraphQLWrapper {
     const result = await this.#client.query(query, args).toPromise()
 
     if (this.#verbose) {
-      console.log(this.describeQueryResult(result)) // Uncomment for debugging.
+      console.log(this.describeQueryResult(result))
     }
 
     if (result.error) {

--- a/packages/connect-thegraph/src/core/GraphQLWrapper.ts
+++ b/packages/connect-thegraph/src/core/GraphQLWrapper.ts
@@ -1,6 +1,7 @@
 import fetch from 'isomorphic-unfetch'
 import ws from 'ws'
 import { Client, defaultExchanges, subscriptionExchange, createRequest } from '@urql/core'
+import { SubscriptionOperation } from '@urql/core/dist/types/exchanges/subscription'
 import { SubscriptionClient } from 'subscriptions-transport-ws'
 import { DocumentNode } from 'graphql'
 import { ParseFunction, QueryResult } from '../types'
@@ -32,7 +33,7 @@ export default class GraphQLWrapper {
       exchanges: [
         ...defaultExchanges,
         subscriptionExchange({
-          forwardSubscription: (operation: any) => subscriptionClient.request(operation)
+          forwardSubscription: (operation: SubscriptionOperation) => subscriptionClient.request(operation)
         })
       ]
     })
@@ -49,7 +50,7 @@ export default class GraphQLWrapper {
 
     return pipe(
       this.#client.executeSubscription(request),
-      subscribe((result: any) => {
+      subscribe((result: QueryResult) => {
         if (this.#verbose) {
           console.log(this.describeQueryResult(result))
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -572,6 +572,13 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
+"@types/ws@^7.2.5":
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.2.5.tgz#513f28b04a1ea1aa9dc2cad3f26e8e37c88aae49"
+  integrity sha512-4UEih9BI1nBKii385G9id1oFrSkLcClbwtDfcYj8HJLQqZVAtb/42vXVrYvRWCcufNF/a+rZD3MxNwghA7UmCg==
+  dependencies:
+    "@types/node" "*"
+
 "@typescript-eslint/eslint-plugin@^2.29.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
@@ -1026,6 +1033,11 @@ babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
+
+backo2@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -2040,6 +2052,11 @@ ethers@^5.0.0-beta.188:
     "@ethersproject/wallet" ">=5.0.0-beta.140"
     "@ethersproject/web" ">=5.0.0-beta.138"
     "@ethersproject/wordlists" ">=5.0.0-beta.136"
+
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
 eventemitter3@^4.0.0:
   version "4.0.4"
@@ -3111,6 +3128,11 @@ isomorphic-unfetch@^3.0.0:
   dependencies:
     node-fetch "^2.2.0"
     unfetch "^4.0.0"
+
+iterall@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
+  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 jest-worker@^25.4.0:
   version "25.5.0"
@@ -4867,6 +4889,17 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
   integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
 
+subscriptions-transport-ws@^0.9.16:
+  version "0.9.16"
+  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz#90a422f0771d9c32069294c08608af2d47f596ec"
+  integrity sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==
+  dependencies:
+    backo2 "^1.0.2"
+    eventemitter3 "^3.1.0"
+    iterall "^1.2.1"
+    symbol-observable "^1.0.4"
+    ws "^5.2.0"
+
 supports-color@6.1.0, supports-color@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
@@ -4892,6 +4925,11 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
+
+symbol-observable@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 table@^5.2.3:
   version "5.4.6"
@@ -5433,6 +5471,13 @@ ws@7.2.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
   integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
+
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  dependencies:
+    async-limiter "~1.0.0"
 
 ws@^6.0.0, ws@^6.2.1:
   version "6.2.1"


### PR DESCRIPTION
This PR implements the low level `subscribeToQuery(...)` function in **connect-thegraph/src/core/GraphQLWrapper.ts**.

See ` inspectVotingLowLevelSubscription(...)` in **examples/organization-viewer-cli/src/index.ts** for usage.
If a vote is created in the org while the demo is running, you will see it pop up in the demo's stdout.

_Note_: Next steps regarding subscriptions is to actually use this low level function in the connectors. This will probably imply slight modifications to how we build gql queries, and an event system that connectors must comply to (`on(...)`, `off(...)`), but not much more than that to have working subscriptions all over.