### PR TITLE
TheGraph Connector: Parse subgraph URL in GraphQLWrapper to catch invalid URLs

### DIFF
--- a/packages/connect-thegraph/src/core/GraphQLWrapper.ts
+++ b/packages/connect-thegraph/src/core/GraphQLWrapper.ts
@@ -17,7 +17,7 @@ export default class GraphQLWrapper {
   #verbose: boolean
 
   constructor(subgraphUrl: string, verbose = false) {
-    if (!subgraphUrl || !subgraphUrl.includes('http')) {
+    if (!subgraphUrl || !subgraphUrl.startsWith('http')) {
        throw new Error('Please provide a valid subgraph URL')
     }
 

--- a/packages/connect-thegraph/src/core/GraphQLWrapper.ts
+++ b/packages/connect-thegraph/src/core/GraphQLWrapper.ts
@@ -17,6 +17,10 @@ export default class GraphQLWrapper {
   #verbose: boolean
 
   constructor(subgraphUrl: string, verbose = false) {
+    if (!subgraphUrl || !subgraphUrl.includes('http')) {
+       throw new Error('Please provide a valid subgraph URL')
+    }
+
     const subscriptionClient = new SubscriptionClient(
       subgraphUrl.replace('http', 'ws'),
       {


### PR DESCRIPTION
From version `0.1` to `0.2` we had a behavior change with urql as it now errors silently if it doesn't have an URL to work with, leading the library to throw a very obscure `cannot read property replace of undefined`. This PR detects if there's no URL passed in, or if it's not valid (doesn't contain `http`, as we're assuming this down below for creating subscriptions) and throws an error with a more meaningful description.

We could also start thinking about making our own errors, extending them from the `Error` class, akin to how `web3-react` handles this.