### PR TITLE
Add support for xdai network

### DIFF
--- a/packages/connect-thegraph/subgraph/manifest/data/xdai-staging.json
+++ b/packages/connect-thegraph/subgraph/manifest/data/xdai-staging.json
@@ -1,0 +1,26 @@
+{
+  "network": "xdai",
+  "description": "Development subgraph for Aragon organizations.",
+  "repository": "https://github.com/aragon/connect",
+  "ens": "0xaafca6b0c89521752e559650206d7c925fd0e530",
+  "DAOFactoryDataSources": [],
+  "RegistryDataSources": [
+    {
+      "name": "aragonpm.eth",
+      "address": "0x3c9fdcf51c3447f629fc61f6aaaf2ac3ea852040",
+      "startBlock": "10076177"
+    },
+    {
+      "name": "1hive.aragonpm.eth",
+      "address": "0x812672c031210b439a5befc8f397d639e97e3738",
+      "startBlock": "10076193"
+    }
+  ],
+  "KernelDataSources": [
+    {
+      "name": "beehive",
+      "address": "0x6a8b8891c5f6de1fcf1ab889e7a06f6b60431641",
+      "startBlock": "10546308"
+    }
+  ]
+}

--- a/packages/connect-thegraph/subgraph/manifest/data/xdai.json
+++ b/packages/connect-thegraph/subgraph/manifest/data/xdai.json
@@ -1,0 +1,22 @@
+{
+  "network": "xdai",
+  "description": "Development subgraph for Aragon organizations.",
+  "repository": "https://github.com/aragon/connect",
+  "ens": "0xaafca6b0c89521752e559650206d7c925fd0e530",
+  "DAOFactoryDataSources": [
+    {
+      "name": "DAOFactory",
+      "address": "0x4037f97fcc94287257e50bd14c7da9cb4df18250",
+      "startBlock": "10076184"
+    }
+  ],
+  "APMFactoryDataSources": [
+    {
+      "name": "ApmRegistryFactory",
+      "address": "0x812672c031210b439a5befc8f397d639e97e3738",
+      "startBlock": "10076185"
+    }
+  ],
+  "RegistryDataSources": [],
+  "KernelDataSources": []
+}

--- a/packages/connect-thegraph/subgraph/manifest/data/xdai.json
+++ b/packages/connect-thegraph/subgraph/manifest/data/xdai.json
@@ -1,6 +1,6 @@
 {
   "network": "xdai",
-  "description": "Development subgraph for Aragon organizations.",
+  "description": "Subgraph for Aragon organizations.",
   "repository": "https://github.com/aragon/connect",
   "ens": "0xaafca6b0c89521752e559650206d7c925fd0e530",
   "DAOFactoryDataSources": [

--- a/packages/connect/src/connect.ts
+++ b/packages/connect/src/connect.ts
@@ -77,6 +77,13 @@ function getNetwork(chainId?: number): Network | null {
       ensAddress: '0x98df287b6c145399aaa709692c8d308357bc085d',
     }
   }
+  if (chainId === 100) {
+    return {
+      chainId: 100,
+      name: 'xdai',
+      ensAddress: '0xaafca6b0c89521752e559650206d7c925fd0e530',
+    }
+  }
   return null
 }
 


### PR DESCRIPTION
1Hive is deploying Aragon Infrastructure to xDai and this is a requirement for `connect` to keep compatible with it.