### PR TITLE
Add a few more things to the PR “Renamed App and Repo”

### DIFF
--- a/docs/api-reference/organization.md
+++ b/docs/api-reference/organization.md
@@ -27,7 +27,7 @@ Install a new app into the organization from a given [aragonPM repository](https
 
 | Name                      | Type                         | Description                                                                                                   |
 | :------------------------ | :--------------------------- | :------------------------------------------------------------------------------------------------------------ |
-| `repoName`                | `String`                     | Repository name \(e.g. `voting.aragonpm.eth`\).                                                               |
+| `repoName`                | `String`                     | Name of the repo \(e.g. `voting.aragonpm.eth`\).                                                               |
 | `options`                 | `Object`                     | Options object.                                                                                               |
 | `options.initFuncName`    | `String`                     | Name of the function that gets called to initialize the app. Set to `none` to skip. Defaults to `initialize`. |
 | `options.initFuncArgs`    | `Array<String>`              | Arguments passed to the function set as `options.initFuncName`. Defaults to `[]`.                             |

--- a/examples/nodejs/src/organization.ts
+++ b/examples/nodejs/src/organization.ts
@@ -18,9 +18,7 @@ async function main() {
   apps.map(console.log)
 
   console.log('\nA voting app:')
-  const votingApp = apps.find(
-    (app: App) => app.name == 'dandelion-voting'
-  )!
+  const votingApp = apps.find((app: App) => app.name == 'dandelion-voting')!
   console.log(votingApp)
 
   console.log('\nRoles of an app:')

--- a/examples/org-viewer-web/src/OrgApps.tsx
+++ b/examples/org-viewer-web/src/OrgApps.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
-import { Application, Organization } from '@aragon/connect'
+import { App, Organization } from '@aragon/connect'
 import Group from './Group'
 import Table from './Table'
 import TextButton from './TextButton'
@@ -12,7 +12,7 @@ type Props = {
 }
 
 export default function OrgApps({ onOpenApp, org }: Props) {
-  const [apps = [], loading] = useCancellableAsync<Application[]>(
+  const [apps = [], loading] = useCancellableAsync<App[]>(
     async () => (org ? org.apps() : []),
     [org]
   )
@@ -23,7 +23,7 @@ export default function OrgApps({ onOpenApp, org }: Props) {
         headers={['Name', 'Version', 'Address']}
         rows={[...apps]
           .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
-          .map((app: Application) => [
+          .map((app: App) => [
             app.name || 'unknown',
             app.version || '?',
             <TextButton onClick={() => onOpenApp(app.address)}>

--- a/packages/connect-core/src/entities/Organization.ts
+++ b/packages/connect-core/src/entities/Organization.ts
@@ -8,6 +8,7 @@ import { ConnectorInterface } from '../connections/ConnectorInterface'
 
 // TODO: Implement all properties and methods from the API spec (https://github.com/aragon/connect/blob/master/docs/organization.md).
 // [x] Organization#apps()
+// [x] Organization#onApps(cb)
 // [x] Organization#app(appAddress)
 // [ ] Organization#addApp(repoName, options)
 // [ ] Organization#removeApp(appAddress)
@@ -19,10 +20,6 @@ import { ConnectorInterface } from '../connections/ConnectorInterface'
 // [ ] Organization#appIntent(appAddress, funcName, funcArgs)
 // [ ] Organization#appCall(appAddress, methodName, args)
 // [ ] Organization#appState(appAddress)
-// [ ] Organization#on(event, params, callback)
-// [ ] Organization#off(event, callback)
-// [ ] Organization#off(event)
-// [ ] Organization#off()
 // [ ] Events...
 
 export default class Organization {

--- a/packages/connect-core/src/entities/Organization.ts
+++ b/packages/connect-core/src/entities/Organization.ts
@@ -86,7 +86,7 @@ export default class Organization {
     return this._connector.appsForOrg(this.address)
   }
 
-  onApps(callback: Function): { unsubscribe: Function } {
+  onApps(callback: (apps: App[]) => void): { unsubscribe: Function } {
     this.checkConnected()
     return this._connector.onAppsForOrg(this.address, callback)
   }

--- a/packages/connect-core/src/types.ts
+++ b/packages/connect-core/src/types.ts
@@ -26,7 +26,7 @@ export interface AppIntent {
 export interface AragonManifest {
   name: string // 'Counter'
   author: string // 'Aragon Association'
-  description: string // 'An application for Aragon'
+  description: string // 'An app for Aragon'
   changelog_url: string // 'https://github.com/aragon/aragon-apps/releases',
   details_url: string // '/meta/details.md'
   source_url: string // 'https://<placeholder-repository-url>'

--- a/packages/connect-core/src/utils/app.ts
+++ b/packages/connect-core/src/utils/app.ts
@@ -24,7 +24,7 @@ export function validateMethod(
   }
 
   // Find the relevant method information
-  const method = methods.find((method) =>
+  const method = methods.find(method =>
     isFullMethodSignature(methodSignature)
       ? method.sig === methodSignature
       : // If the full signature isn't given, just select the first overload declared
@@ -62,7 +62,7 @@ export function findAppMethodFromIntent(
   let method
   // First try to find the method in the current functions
   if (Array.isArray(intents)) {
-    method = intents.find((method) => checkMethodSignature(method.sig))
+    method = intents.find(method => checkMethodSignature(method.sig))
   }
 
   if (!method) {
@@ -75,7 +75,7 @@ export function findAppMethodFromIntent(
       const allDeprecatedFunctions = ([] as AppIntent[]).concat(
         ...deprecatedFunctionsFromVersions
       )
-      method = allDeprecatedFunctions.find((method) =>
+      method = allDeprecatedFunctions.find(method =>
         checkMethodSignature(method.sig)
       )
     }

--- a/packages/connect-thegraph/src/connector.ts
+++ b/packages/connect-thegraph/src/connector.ts
@@ -1,7 +1,7 @@
 import {
+  App,
   ConnectorInterface,
   Permission,
-  App,
   Repo,
   Role,
 } from '@aragon/connect-core'

--- a/packages/connect-thegraph/src/parsers/apps.ts
+++ b/packages/connect-thegraph/src/parsers/apps.ts
@@ -1,10 +1,7 @@
 import { App, AppData } from '@aragon/connect-core'
 import { QueryResult } from '../types'
 
-function _parseApp(
-  app: any,
-  connector: any
-): App{
+function _parseApp(app: any, connector: any): App {
   const data: AppData = {
     address: app.address,
     appId: app.appId,
@@ -25,10 +22,7 @@ function _parseApp(
   return new App(data, connector)
 }
 
-export function parseApp(
-  result: QueryResult,
-  connector: any
-): AppData {
+export function parseApp(result: QueryResult, connector: any): AppData {
   const app = result.data.app
 
   if (!app) {
@@ -38,10 +32,7 @@ export function parseApp(
   return _parseApp(app, connector)
 }
 
-export function parseApps(
-  result: QueryResult,
-  connector: any
-): AppData[] {
+export function parseApps(result: QueryResult, connector: any): AppData[] {
   const org = result.data.organization
   const apps = org?.apps
 


### PR DESCRIPTION
Adding a few more things to the PR:

- Move examples to use `App`.
- Update some comments and formatting.
- Update the TODO in Organization.ts
- [Improve a callback type](https://github.com/aragon/connect/compare/rename-app-and-repo...rename-app-and-repo-more?expand=1#diff-da82e438aa17d498b7f7c1350529ed4cR89) (this one doesn’t really belong here but is really minor, let me know if you prefer to remove it).