### PR TITLE
Feat: Add overrides for apps without aragonPM repos

### DIFF
--- a/packages/connect-core/src/entities/App.ts
+++ b/packages/connect-core/src/entities/App.ts
@@ -10,6 +10,11 @@ import {
 } from '../types'
 import { resolveMetadata } from '../utils/metadata'
 import { ConnectorInterface } from '../connections/ConnectorInterface'
+import {
+  getApmInternalAppInfo,
+  getAragonOsInternalAppInfo,
+} from '../utils/overrides/index'
+import { hasAppInfo } from '../utils/overrides/interfaces'
 
 // TODO:
 // [ ] (ipfs) contentUrl 	String 	The HTTP URL of the app content. Uses the IPFS HTTP provider. E.g. http://gateway.ipfs.io/ipfs/QmdLEDDfi…/ (ContentUri passing through the resolver)
@@ -73,11 +78,18 @@ export default class App extends CoreEntity {
     data: AppData,
     connector: ConnectorInterface
   ): Promise<App> {
-    const artifact: AragonArtifact = await resolveMetadata(
-      'artifact.json',
-      data.contentUri || undefined,
-      data.artifact
-    )
+    let artifact: AragonArtifact
+    if (hasAppInfo(data.appId, 'apm')) {
+      artifact = getApmInternalAppInfo(data.appId)
+    } else if (hasAppInfo(data.appId, 'aragon')) {
+      artifact = getAragonOsInternalAppInfo(data.appId)
+    } else {
+      artifact = await resolveMetadata(
+        'artifact.json',
+        data.contentUri || undefined,
+        data.artifact
+      )
+    }
 
     const manifest: AragonManifest = await resolveMetadata(
       'manifest.json',

--- a/packages/connect-core/src/utils/app.ts
+++ b/packages/connect-core/src/utils/app.ts
@@ -4,6 +4,9 @@ import { AppIntent } from '../types'
 import App from '../entities/App'
 import { TransactionRequestData } from '../transactions/TransactionRequest'
 
+export const apmAppId = (appName: string): string =>
+  ethers.utils.namehash(`${appName}.aragonpm.eth`)
+
 // Is the given method a full signature, e.g. 'foo(arg1,arg2,...)'
 export const isFullMethodSignature = (methodSignature: string): boolean => {
   return (

--- a/packages/connect-core/src/utils/overrides/abi/ACL.json
+++ b/packages/connect-core/src/utils/overrides/abi/ACL.json
@@ -1,0 +1,775 @@
+{
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "hasInitialized",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "NO_PERMISSION",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_script",
+          "type": "bytes"
+        }
+      ],
+      "name": "getEVMScriptExecutor",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getRecoveryVault",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "CREATE_PERMISSIONS_ROLE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "allowRecoverability",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "appId",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getInitializationBlock",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_token",
+          "type": "address"
+        }
+      ],
+      "name": "transferToVault",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_sender",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        },
+        {
+          "name": "_params",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "canPerform",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getEVMScriptRegistry",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "ANY_ENTITY",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "EMPTY_PARAM_HASH",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "kernel",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "isPetrified",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "BURN_ENTITY",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "entity",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "app",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "name": "allowed",
+          "type": "bool"
+        }
+      ],
+      "name": "SetPermission",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "entity",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "app",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "name": "paramsHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "SetPermissionParams",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "app",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "name": "manager",
+          "type": "address"
+        }
+      ],
+      "name": "ChangePermissionManager",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "executor",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "script",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "input",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "name": "ScriptResult",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "RecoverToVault",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_permissionsCreator",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_entity",
+          "type": "address"
+        },
+        {
+          "name": "_app",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        },
+        {
+          "name": "_manager",
+          "type": "address"
+        }
+      ],
+      "name": "createPermission",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_entity",
+          "type": "address"
+        },
+        {
+          "name": "_app",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "grantPermission",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_entity",
+          "type": "address"
+        },
+        {
+          "name": "_app",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        },
+        {
+          "name": "_params",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "grantPermissionP",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_entity",
+          "type": "address"
+        },
+        {
+          "name": "_app",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "revokePermission",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_newManager",
+          "type": "address"
+        },
+        {
+          "name": "_app",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPermissionManager",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_app",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "removePermissionManager",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_app",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "createBurnedPermission",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_app",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "burnPermissionManager",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_entity",
+          "type": "address"
+        },
+        {
+          "name": "_app",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getPermissionParamsLength",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_entity",
+          "type": "address"
+        },
+        {
+          "name": "_app",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        },
+        {
+          "name": "_index",
+          "type": "uint256"
+        }
+      ],
+      "name": "getPermissionParam",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint8"
+        },
+        {
+          "name": "",
+          "type": "uint8"
+        },
+        {
+          "name": "",
+          "type": "uint240"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_app",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getPermissionManager",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_who",
+          "type": "address"
+        },
+        {
+          "name": "_where",
+          "type": "address"
+        },
+        {
+          "name": "_what",
+          "type": "bytes32"
+        }
+      ],
+      "name": "hasPermission",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_who",
+          "type": "address"
+        },
+        {
+          "name": "_where",
+          "type": "address"
+        },
+        {
+          "name": "_what",
+          "type": "bytes32"
+        },
+        {
+          "name": "_how",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "hasPermission",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_who",
+          "type": "address"
+        },
+        {
+          "name": "_where",
+          "type": "address"
+        },
+        {
+          "name": "_what",
+          "type": "bytes32"
+        },
+        {
+          "name": "_how",
+          "type": "bytes"
+        }
+      ],
+      "name": "hasPermission",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_paramsHash",
+          "type": "bytes32"
+        },
+        {
+          "name": "_who",
+          "type": "address"
+        },
+        {
+          "name": "_where",
+          "type": "address"
+        },
+        {
+          "name": "_what",
+          "type": "bytes32"
+        },
+        {
+          "name": "_how",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "evalParams",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/packages/connect-core/src/utils/overrides/abi/APMRegistry.json
+++ b/packages/connect-core/src/utils/overrides/abi/APMRegistry.json
@@ -1,0 +1,488 @@
+{
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "hasInitialized",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_script",
+          "type": "bytes"
+        }
+      ],
+      "name": "getEVMScriptExecutor",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "registrar",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getRecoveryVault",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "ens",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "CREATE_REPO_ROLE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "allowRecoverability",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "appId",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getInitializationBlock",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_token",
+          "type": "address"
+        }
+      ],
+      "name": "transferToVault",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_sender",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        },
+        {
+          "name": "_params",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "canPerform",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getEVMScriptRegistry",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_kernel",
+          "type": "address"
+        },
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        },
+        {
+          "name": "_initializePayload",
+          "type": "bytes"
+        }
+      ],
+      "name": "newAppProxyPinned",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "kernel",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "isPetrified",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_kernel",
+          "type": "address"
+        },
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "newAppProxy",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_kernel",
+          "type": "address"
+        },
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        },
+        {
+          "name": "_initializePayload",
+          "type": "bytes"
+        }
+      ],
+      "name": "newAppProxy",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_kernel",
+          "type": "address"
+        },
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "newAppProxyPinned",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "id",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "name": "repo",
+          "type": "address"
+        }
+      ],
+      "name": "NewRepo",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "proxy",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "isUpgradeable",
+          "type": "bool"
+        },
+        {
+          "indexed": false,
+          "name": "appId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "NewAppProxy",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "executor",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "script",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "input",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "name": "ScriptResult",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "RecoverToVault",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_registrar",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "name": "_dev",
+          "type": "address"
+        }
+      ],
+      "name": "newRepo",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "name": "_dev",
+          "type": "address"
+        },
+        {
+          "name": "_initialSemanticVersion",
+          "type": "uint16[3]"
+        },
+        {
+          "name": "_contractAddress",
+          "type": "address"
+        },
+        {
+          "name": "_contentURI",
+          "type": "bytes"
+        }
+      ],
+      "name": "newRepoWithVersion",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/packages/connect-core/src/utils/overrides/abi/ENSSubdomainRegistrar.json
+++ b/packages/connect-core/src/utils/overrides/abi/ENSSubdomainRegistrar.json
@@ -1,0 +1,426 @@
+{
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "hasInitialized",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_script",
+          "type": "bytes"
+        }
+      ],
+      "name": "getEVMScriptExecutor",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "POINT_ROOTNODE_ROLE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getRecoveryVault",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "ens",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "allowRecoverability",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "appId",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getInitializationBlock",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_token",
+          "type": "address"
+        }
+      ],
+      "name": "transferToVault",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_sender",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        },
+        {
+          "name": "_params",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "canPerform",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getEVMScriptRegistry",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "DELETE_NAME_ROLE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "kernel",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "isPetrified",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "rootNode",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "CREATE_NAME_ROLE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "node",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "name": "label",
+          "type": "bytes32"
+        }
+      ],
+      "name": "NewName",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "node",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "name": "label",
+          "type": "bytes32"
+        }
+      ],
+      "name": "DeleteName",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "executor",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "script",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "input",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "name": "ScriptResult",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "RecoverToVault",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_ens",
+          "type": "address"
+        },
+        {
+          "name": "_rootNode",
+          "type": "bytes32"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_label",
+          "type": "bytes32"
+        },
+        {
+          "name": "_owner",
+          "type": "address"
+        }
+      ],
+      "name": "createName",
+      "outputs": [
+        {
+          "name": "node",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_label",
+          "type": "bytes32"
+        },
+        {
+          "name": "_target",
+          "type": "address"
+        }
+      ],
+      "name": "createNameAndPoint",
+      "outputs": [
+        {
+          "name": "node",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_label",
+          "type": "bytes32"
+        }
+      ],
+      "name": "deleteName",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_target",
+          "type": "address"
+        }
+      ],
+      "name": "pointRootNode",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/packages/connect-core/src/utils/overrides/abi/EVMScriptRegistry.json
+++ b/packages/connect-core/src/utils/overrides/abi/EVMScriptRegistry.json
@@ -1,0 +1,390 @@
+{
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "hasInitialized",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "REGISTRY_ADD_EXECUTOR_ROLE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_script",
+          "type": "bytes"
+        }
+      ],
+      "name": "getEVMScriptExecutor",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getRecoveryVault",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "allowRecoverability",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "appId",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getInitializationBlock",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_token",
+          "type": "address"
+        }
+      ],
+      "name": "transferToVault",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_sender",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        },
+        {
+          "name": "_params",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "canPerform",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getEVMScriptRegistry",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "REGISTRY_MANAGER_ROLE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "kernel",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "isPetrified",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "executors",
+      "outputs": [
+        {
+          "name": "executor",
+          "type": "address"
+        },
+        {
+          "name": "enabled",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "executorId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "name": "executorAddress",
+          "type": "address"
+        }
+      ],
+      "name": "EnableExecutor",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "executorId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "name": "executorAddress",
+          "type": "address"
+        }
+      ],
+      "name": "DisableExecutor",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "executor",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "script",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "input",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "name": "ScriptResult",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "RecoverToVault",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_executor",
+          "type": "address"
+        }
+      ],
+      "name": "addScriptExecutor",
+      "outputs": [
+        {
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_executorId",
+          "type": "uint256"
+        }
+      ],
+      "name": "disableScriptExecutor",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_executorId",
+          "type": "uint256"
+        }
+      ],
+      "name": "enableScriptExecutor",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_script",
+          "type": "bytes"
+        }
+      ],
+      "name": "getScriptExecutor",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/packages/connect-core/src/utils/overrides/abi/Kernel.json
+++ b/packages/connect-core/src/utils/overrides/abi/Kernel.json
@@ -1,0 +1,621 @@
+{
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "hasInitialized",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        },
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "apps",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "allowRecoverability",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "recoveryVaultAppId",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getInitializationBlock",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "APP_MANAGER_ROLE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_token",
+          "type": "address"
+        }
+      ],
+      "name": "transferToVault",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_kernel",
+          "type": "address"
+        },
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        },
+        {
+          "name": "_initializePayload",
+          "type": "bytes"
+        }
+      ],
+      "name": "newAppProxyPinned",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "isPetrified",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_kernel",
+          "type": "address"
+        },
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "newAppProxy",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_kernel",
+          "type": "address"
+        },
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        },
+        {
+          "name": "_initializePayload",
+          "type": "bytes"
+        }
+      ],
+      "name": "newAppProxy",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_kernel",
+          "type": "address"
+        },
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "newAppProxyPinned",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "name": "_shouldPetrify",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "proxy",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "isUpgradeable",
+          "type": "bool"
+        },
+        {
+          "indexed": false,
+          "name": "appId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "NewAppProxy",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "RecoverToVault",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "namespace",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "name": "appId",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "name": "app",
+          "type": "address"
+        }
+      ],
+      "name": "SetApp",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_baseAcl",
+          "type": "address"
+        },
+        {
+          "name": "_permissionsCreator",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        },
+        {
+          "name": "_appBase",
+          "type": "address"
+        },
+        {
+          "name": "_initializePayload",
+          "type": "bytes"
+        },
+        {
+          "name": "_setDefault",
+          "type": "bool"
+        }
+      ],
+      "name": "newAppInstance",
+      "outputs": [
+        {
+          "name": "appProxy",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        },
+        {
+          "name": "_appBase",
+          "type": "address"
+        }
+      ],
+      "name": "newAppInstance",
+      "outputs": [
+        {
+          "name": "appProxy",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        },
+        {
+          "name": "_appBase",
+          "type": "address"
+        }
+      ],
+      "name": "newPinnedAppInstance",
+      "outputs": [
+        {
+          "name": "appProxy",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        },
+        {
+          "name": "_appBase",
+          "type": "address"
+        },
+        {
+          "name": "_initializePayload",
+          "type": "bytes"
+        },
+        {
+          "name": "_setDefault",
+          "type": "bool"
+        }
+      ],
+      "name": "newPinnedAppInstance",
+      "outputs": [
+        {
+          "name": "appProxy",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_namespace",
+          "type": "bytes32"
+        },
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        },
+        {
+          "name": "_app",
+          "type": "address"
+        }
+      ],
+      "name": "setApp",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_recoveryVaultAppId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setRecoveryVaultAppId",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "CORE_NAMESPACE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "APP_BASES_NAMESPACE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "APP_ADDR_NAMESPACE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "KERNEL_APP_ID",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "DEFAULT_ACL_APP_ID",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_namespace",
+          "type": "bytes32"
+        },
+        {
+          "name": "_appId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getApp",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getRecoveryVault",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "acl",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_who",
+          "type": "address"
+        },
+        {
+          "name": "_where",
+          "type": "address"
+        },
+        {
+          "name": "_what",
+          "type": "bytes32"
+        },
+        {
+          "name": "_how",
+          "type": "bytes"
+        }
+      ],
+      "name": "hasPermission",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/packages/connect-core/src/utils/overrides/abi/Repo.json
+++ b/packages/connect-core/src/utils/overrides/abi/Repo.json
@@ -1,0 +1,432 @@
+{
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "hasInitialized",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_script",
+          "type": "bytes"
+        }
+      ],
+      "name": "getEVMScriptExecutor",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getRecoveryVault",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "allowRecoverability",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "appId",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getInitializationBlock",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_token",
+          "type": "address"
+        }
+      ],
+      "name": "transferToVault",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_sender",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        },
+        {
+          "name": "_params",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "canPerform",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getEVMScriptRegistry",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "CREATE_VERSION_ROLE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "kernel",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "isPetrified",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "versionId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "name": "semanticVersion",
+          "type": "uint16[3]"
+        }
+      ],
+      "name": "NewVersion",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "executor",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "script",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "input",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "name": "ScriptResult",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "RecoverToVault",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_newSemanticVersion",
+          "type": "uint16[3]"
+        },
+        {
+          "name": "_contractAddress",
+          "type": "address"
+        },
+        {
+          "name": "_contentURI",
+          "type": "bytes"
+        }
+      ],
+      "name": "newVersion",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getLatest",
+      "outputs": [
+        {
+          "name": "semanticVersion",
+          "type": "uint16[3]"
+        },
+        {
+          "name": "contractAddress",
+          "type": "address"
+        },
+        {
+          "name": "contentURI",
+          "type": "bytes"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_contractAddress",
+          "type": "address"
+        }
+      ],
+      "name": "getLatestForContractAddress",
+      "outputs": [
+        {
+          "name": "semanticVersion",
+          "type": "uint16[3]"
+        },
+        {
+          "name": "contractAddress",
+          "type": "address"
+        },
+        {
+          "name": "contentURI",
+          "type": "bytes"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_semanticVersion",
+          "type": "uint16[3]"
+        }
+      ],
+      "name": "getBySemanticVersion",
+      "outputs": [
+        {
+          "name": "semanticVersion",
+          "type": "uint16[3]"
+        },
+        {
+          "name": "contractAddress",
+          "type": "address"
+        },
+        {
+          "name": "contentURI",
+          "type": "bytes"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_versionId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getByVersionId",
+      "outputs": [
+        {
+          "name": "semanticVersion",
+          "type": "uint16[3]"
+        },
+        {
+          "name": "contractAddress",
+          "type": "address"
+        },
+        {
+          "name": "contentURI",
+          "type": "bytes"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getVersionsCount",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_oldVersion",
+          "type": "uint16[3]"
+        },
+        {
+          "name": "_newVersion",
+          "type": "uint16[3]"
+        }
+      ],
+      "name": "isValidBump",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "pure",
+      "type": "function"
+    }
+  ]
+}

--- a/packages/connect-core/src/utils/overrides/artifacts/apm/APMRegistry.json
+++ b/packages/connect-core/src/utils/overrides/artifacts/apm/APMRegistry.json
@@ -1,0 +1,32 @@
+{
+  "appName": "apm-registry.aragonpm.eth",
+	"roles": [
+		{
+			"id": "CREATE_REPO_ROLE",
+			"bytes": "0x2a9494d64846c9fdbf0158785aa330d8bc9caf45af27fa0e8898eb4d55adcea6",
+			"name": "Create repos",
+			"params": []
+		}
+	],
+	"functions": [
+		{
+			"sig": "initialize(address)",
+			"roles": [],
+			"notice": "Initialize this APMRegistry instance and set `_registrar` as the ENS subdomain registrar"
+		},
+		{
+			"sig": "newRepo(string,address)",
+			"roles": [
+				"CREATE_REPO_ROLE"
+			],
+			"notice": "Create new repo in registry with `_name`"
+		},
+		{
+			"sig": "newRepoWithVersion(string,address,uint16[3],address,bytes)",
+			"roles": [
+				"CREATE_REPO_ROLE"
+			],
+			"notice": "Create new repo in registry with `_name` and publish a first version with contract `_contractAddress` and content `@fromHex(_contentURI)`"
+		}
+	]
+}

--- a/packages/connect-core/src/utils/overrides/artifacts/apm/ENSSubdomainRegistrar.json
+++ b/packages/connect-core/src/utils/overrides/artifacts/apm/ENSSubdomainRegistrar.json
@@ -1,0 +1,58 @@
+{
+  "appName": "apm-enssub.aragonpm.eth",
+	"roles": [
+		{
+			"id": "CREATE_NAME_ROLE",
+			"bytes": "0xf86bc2abe0919ab91ef714b2bec7c148d94f61fdb069b91a6cfe9ecdee1799ba",
+			"name": "Create subdomains",
+			"params": []
+		},
+		{
+			"id": "DELETE_NAME_ROLE",
+			"bytes": "0x03d74c8724218ad4a99859bcb2d846d39999449fd18013dd8d69096627e68622",
+			"name": "Remove subdomains",
+			"params": []
+		},
+		{
+			"id": "POINT_ROOTNODE_ROLE",
+			"bytes": "0x9ecd0e7bddb2e241c41b595a436c4ea4fd33c9fa0caa8056acf084fc3aa3bfbe",
+			"name": "Point root domain",
+			"params": []
+		}
+	],
+	"functions": [
+		{
+			"sig": "initialize(address,bytes32)",
+			"roles": [],
+			"notice": "Initialize this ENSSubdomainRegistrar instance with `_ens` as the root ENS registry and `_rootNode` as the node to allocate subdomains under"
+		},
+		{
+			"sig": "createName(bytes32,address)",
+			"roles": [
+				"CREATE_NAME_ROLE"
+			],
+			"notice": "Create a new ENS subdomain record for `_label` and assign ownership to `_owner`"
+		},
+		{
+			"sig": "createNameAndPoint(bytes32,address)",
+			"roles": [
+				"CREATE_NAME_ROLE"
+			],
+			"notice": "Create a new ENS subdomain record for `_label` that resolves to `_target` and is owned by this ENSSubdomainRegistrar"
+		},
+		{
+			"sig": "deleteName(bytes32)",
+			"roles": [
+				"DELETE_NAME_ROLE"
+			],
+			"notice": "Deregister ENS subdomain record for `_label`"
+		},
+		{
+			"sig": "pointRootNode(address)",
+			"roles": [
+				"POINT_ROOTNODE_ROLE"
+			],
+			"notice": "Resolve this ENSSubdomainRegistrar's root node to `_target`"
+		}
+	]
+}

--- a/packages/connect-core/src/utils/overrides/artifacts/apm/Repo.json
+++ b/packages/connect-core/src/utils/overrides/artifacts/apm/Repo.json
@@ -1,0 +1,25 @@
+{
+  "appName": "apm-repo.aragonpm.eth",
+	"roles": [
+		{
+			"id": "CREATE_VERSION_ROLE",
+			"bytes": "0x1f56cfecd3595a2e6cc1a7e6cb0b20df84cdbd92eff2fee554e70e4e45a9a7d8",
+			"name": "Publish versions",
+			"params": []
+		}
+	],
+	"functions": [
+		{
+			"sig": "initialize()",
+			"roles": [],
+			"notice": "Initialize this Repo"
+		},
+		{
+			"sig": "newVersion(uint16[3],address,bytes)",
+			"roles": [
+				"CREATE_VERSION_ROLE"
+			],
+			"notice": "Create new version with contract `_contractAddress` and content `@fromHex(_contentURI)`"
+		}
+	]
+}

--- a/packages/connect-core/src/utils/overrides/artifacts/aragon/ACL.json
+++ b/packages/connect-core/src/utils/overrides/artifacts/aragon/ACL.json
@@ -1,0 +1,82 @@
+{
+  "appName": "acl.aragonpm.eth",
+  "roles": [
+    {
+      "name": "Create permissions",
+      "id": "CREATE_PERMISSIONS_ROLE",
+      "bytes": "0x0b719b33c83b8e5d300c521cb8b54ae9bd933996a14bef8c2f4e0285d2d2400a"
+    }
+  ],
+  "functions": [
+    {
+        "sig":"initialize(address)",
+        "roles":[
+
+        ],
+        "notice":"Initializes an ACL instance and sets `_permissionsCreator` as the entity that can create other permissions"
+    },
+    {
+        "sig":"createPermission(address,address,bytes32,address)",
+        "roles":[
+            "CREATE_PERMISSIONS_ROLE"
+        ],
+        "notice":"Create a new permission granting `_entity` the ability to perform actions of role `_role` on `_app` (setting `_manager` as the permission manager)"
+    },
+    {
+        "sig":"grantPermission(address,address,bytes32)",
+        "roles":[
+
+        ],
+        "notice":"Grants `_entity` the ability to perform actions of role `_role` on `_app`"
+    },
+    {
+        "sig":"grantPermissionP(address,address,bytes32,uint256[])",
+        "roles":[
+
+        ],
+        "notice":"Grants `_entity` the ability to perform actions of role `_role` on `_app`"
+    },
+    {
+        "sig":"revokePermission(address,address,bytes32)",
+        "roles":[
+
+        ],
+        "notice":"Revokes `_entity` the ability to perform actions of role `_role` on `_app`"
+    },
+    {
+        "sig":"setPermissionManager(address,address,bytes32)",
+        "roles":[
+
+        ],
+        "notice":"Sets `_newManager` as the manager of the permission `_role` in `_app`"
+    },
+    {
+        "sig":"removePermissionManager(address,bytes32)",
+        "roles":[
+
+        ],
+        "notice":"Removes the manager of the permission `_role` in `_app`"
+    },
+    {
+        "sig":"getPermissionParam(address,address,address)",
+        "roles":[
+
+        ],
+        "notice":"Get parameter for permission"
+    },
+    {
+        "sig":"_evalLogic(address,bytes32,address,address,bytes32,uint256[])",
+        "roles":[
+
+        ],
+        "notice":null
+    },
+    {
+      "sig":"transferToVault(address)",
+      "roles":[
+
+      ],
+      "notice":"Send funds to recovery Vault. This contract should never receive funds, but in case it does, this function allows one to recover them."
+    }
+  ]
+}

--- a/packages/connect-core/src/utils/overrides/artifacts/aragon/EVMScriptRegistry.json
+++ b/packages/connect-core/src/utils/overrides/artifacts/aragon/EVMScriptRegistry.json
@@ -1,0 +1,52 @@
+{
+  "appName": "evmreg.aragonpm.eth",
+  "roles": [
+    {
+      "name": "Add executors",
+      "id": "REGISTRY_ADD_EXECUTOR_ROLE",
+      "bytes": "0xc4e90f38eea8c4212a009ca7b8947943ba4d4a58d19b683417f65291d1cd9ed2"
+    },
+    {
+      "name": "Enable and disable executors",
+      "id": "REGISTRY_MANAGER_ROLE",
+      "bytes": "0xf7a450ef335e1892cb42c8ca72e7242359d7711924b75db5717410da3f614aa3"
+    }
+  ],
+  "functions": [
+    {
+      "sig":"initialize()",
+      "roles":[
+
+      ],
+      "notice":"Initialize the registry"
+    },
+    {
+      "sig":"addScriptExecutor(address)",
+      "roles":[
+          "REGISTRY_ADD_EXECUTOR_ROLE"
+      ],
+      "notice":"Add a new script executor with address `_executor` to the registry"
+    },
+    {
+      "sig":"disableScriptExecutor(uint256)",
+      "roles":[
+          "REGISTRY_MANAGER_ROLE"
+      ],
+      "notice":"Disable script executor with ID `_executorId`"
+    },
+    {
+      "sig":"enableScriptExecutor(uint256)",
+      "roles":[
+          "REGISTRY_MANAGER_ROLE"
+      ],
+      "notice":"Enable script executor with ID `_executorId`"
+    },
+    {
+      "sig":"transferToVault(address)",
+      "roles":[
+
+      ],
+      "notice":"Send funds to recovery Vault. This contract should never receive funds, but in case it does, this function allows one to recover them."
+    } 
+  ]
+}

--- a/packages/connect-core/src/utils/overrides/artifacts/aragon/Kernel.json
+++ b/packages/connect-core/src/utils/overrides/artifacts/aragon/Kernel.json
@@ -1,0 +1,73 @@
+{
+  "appName": "kernel.aragonpm.eth",
+  "roles": [
+    {
+      "name": "Manage apps",
+      "id": "APP_MANAGER_ROLE",
+      "bytes": "0xb6d92708f3d4817afc106147d969e229ced5c46e65e0a5002a0d391287762bd0"
+    },
+    {
+      "name": "Manage profile",
+      "id": "MANAGE_PROFILE_ROLE",
+      "bytes": "0x675b358b95ae7561136697fcc3302da54a334ac7c199d53621288290fb863f5c"
+    }
+  ],
+  "functions": [
+    {
+      "sig":"initialize(address,address)",
+      "roles":[
+
+      ],
+      "notice":"Initializes a kernel instance along with its ACL and sets `_permissionsCreator` as the entity that can create other permissions"
+    },
+    {
+      "sig":"newAppInstance(bytes32,address)",
+      "roles":[
+          "APP_MANAGER_ROLE"
+      ],
+      "notice":"Create a new upgradeable instance of `_appId` app linked to the Kernel, setting its code to `_appBase`"
+    },
+    {
+      "sig":"newAppInstance(bytes32,address,bytes,bool)",
+      "roles":[
+          "APP_MANAGER_ROLE"
+      ],
+      "notice":"Create a new upgradeable instance of `_appId` app linked to the Kernel, setting its code to `_appBase`. `_setDefault ? 'Also sets it as the default app instance.':''`"
+    },
+    {
+      "sig":"newPinnedAppInstance(bytes32,address)",
+      "roles":[
+          "APP_MANAGER_ROLE"
+      ],
+      "notice":"Create a new non-upgradeable instance of `_appId` app linked to the Kernel, setting its code to `_appBase`."
+    },
+    {
+      "sig":"newPinnedAppInstance(bytes32,address,bytes,bool)",
+      "roles":[
+          "APP_MANAGER_ROLE"
+      ],
+      "notice":"Create a new non-upgradeable instance of `_appId` app linked to the Kernel, setting its code to `_appBase`. `_setDefault ? 'Also sets it as the default app instance.':''`"
+    },
+    {
+      "sig":"setApp(bytes32,bytes32,address)",
+      "roles":[
+          "APP_MANAGER_ROLE"
+      ],
+      "notice":"Set the resolving address of `_appId` in namespace `_namespace` to `_app`"
+    },
+    {
+      "sig":"setRecoveryVaultAppId(bytes32)",
+      "roles":[
+          "APP_MANAGER_ROLE"
+      ],
+      "notice":null
+    },
+    {
+      "sig":"transferToVault(address)",
+      "roles":[
+
+      ],
+      "notice":"Send funds to recovery Vault. This contract should never receive funds, but in case it does, this function allows one to recover them."
+    }    
+  ]
+}

--- a/packages/connect-core/src/utils/overrides/index.ts
+++ b/packages/connect-core/src/utils/overrides/index.ts
@@ -1,0 +1,10 @@
+import { getAppInfo } from './interfaces'
+import { AragonArtifact } from '../../types'
+
+export function getAragonOsInternalAppInfo(appId: string): AragonArtifact {
+  return getAppInfo(appId, 'aragon')
+}
+
+export function getApmInternalAppInfo(appId: string): AragonArtifact {
+  return getAppInfo(appId, 'apm')
+}

--- a/packages/connect-core/src/utils/overrides/interfaces.ts
+++ b/packages/connect-core/src/utils/overrides/interfaces.ts
@@ -1,0 +1,91 @@
+import { apmAppId } from '../app'
+
+// ABIs
+import abiAragonACL from './abi/ACL.json'
+import abiAragonKernel from './abi/Kernel.json'
+import abiAragonEVMScriptRegistry from './abi/EVMScriptRegistry.json'
+import abiApmRegistry from './abi/APMRegistry.json'
+import abiApmRepo from './abi/Repo.json'
+import abiApmEnsSubdomainRegistrar from './abi/ENSSubdomainRegistrar.json'
+
+// Artifacts
+import artifactsAragonACL from './artifacts/aragon/ACL.json'
+import artifactsAragonKernel from './artifacts/aragon/Kernel.json'
+import artifactsAragonEVMScriptRegistry from './artifacts/aragon/EVMScriptRegistry.json'
+import artifactsApmRegistry from './artifacts/apm/APMRegistry.json'
+import artifactsApmRepo from './artifacts/apm/Repo.json'
+import artifactsApmEnsSubdomainRegistrar from './artifacts/apm/ENSSubdomainRegistrar.json'
+import { Abi } from '../../types'
+
+const ABIS: { [key: string]: any[] } = {
+  'aragon/ACL': abiAragonACL.abi,
+  'aragon/Kernel': abiAragonKernel.abi,
+  'aragon/EVM Script Registry': abiAragonEVMScriptRegistry.abi,
+  'apm/APM Registry': abiApmRegistry.abi,
+  'apm/Repo': abiApmRepo.abi,
+  'apm/ENS Subdomain Registrar': abiApmEnsSubdomainRegistrar.abi,
+}
+
+const ARTIFACTS: { [key: string]: any } = {
+  'aragon/ACL': artifactsAragonACL,
+  'aragon/Kernel': artifactsAragonKernel,
+  'aragon/EVM Script Registry': artifactsAragonEVMScriptRegistry,
+  'apm/APM Registry': artifactsApmRegistry,
+  'apm/Repo': artifactsApmRepo,
+  'apm/ENS Subdomain Registrar': artifactsApmEnsSubdomainRegistrar,
+}
+
+const SYSTEM_APP_MAPPINGS = new Map([
+  [apmAppId('acl'), 'ACL'],
+  [apmAppId('evmreg'), 'EVM Script Registry'],
+  [apmAppId('kernel'), 'Kernel'],
+])
+
+const APM_APP_MAPPINGS = new Map([
+  [apmAppId('apm-registry'), 'APM Registry'],
+  [apmAppId('apm-repo'), 'Repo'],
+  [apmAppId('apm-enssub'), 'ENS Subdomain Registrar'],
+  // Support open.aragonpm.eth's native packages
+  // Note that these were erroneously deployed on the open.aragonpm.eth instance rather than
+  // reusing the aragonpm.eth versions
+  [apmAppId('apm-registry.open'), 'APM Registry'],
+  [apmAppId('apm-repo.open'), 'Repo'],
+  [apmAppId('apm-enssub.open'), 'ENS Subdomain Registrar'],
+  // Support hatch.aragonpm.eth's native packages (see note above for `open.aragonpm.eth`)
+  [apmAppId('apm-registry.hatch'), 'APM Registry'],
+  [apmAppId('apm-repo.hatch'), 'Repo'],
+  [apmAppId('apm-enssub.hatch'), 'ENS Subdomain Registrar'],
+])
+
+const APP_NAMESPACE_MAPPINGS = new Map([
+  ['aragon', SYSTEM_APP_MAPPINGS],
+  ['apm', APM_APP_MAPPINGS],
+])
+
+export const getAbi = (name: string): Abi => ABIS[name] || null
+export const getArtifact = (name: string): any => ARTIFACTS[name] || null
+
+export function getAppInfo(appId: string, namespace: string): any {
+  const nameMapping = APP_NAMESPACE_MAPPINGS.get(namespace)
+
+  if (!nameMapping || !nameMapping.has(appId)) {
+    return null
+  }
+
+  const appName = nameMapping.get(appId)
+  const app = `${namespace}/${appName}`
+  const abi = getAbi(app)
+  const artifact = getArtifact(app)
+
+  return {
+    abi,
+    appName,
+    ...artifact,
+  }
+}
+
+export function hasAppInfo(appId: string, namespace: string): boolean {
+  const mapping = APP_NAMESPACE_MAPPINGS.get(namespace)
+  if (mapping) return Boolean(mapping) && mapping.has(appId)
+  return false
+}

--- a/packages/connect-core/tsconfig.json
+++ b/packages/connect-core/tsconfig.json
@@ -2,8 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
   },
-  "include": ["src"],
+  "include": ["src", "src/**/*.json"],
   "exclude": ["dist", "**/__test__/**"]
 }


### PR DESCRIPTION
Includes manual override of the artifact metadata for apps without an aragonPM repo:
- Kernel
- ACL
- EVM Script Registry
- Repo
- APM Registry
- ENS Subdomain Registrar