### PR TITLE
Docs: Use \| as separators

### DIFF
--- a/docs/api-reference/connect.md
+++ b/docs/api-reference/connect.md
@@ -9,7 +9,7 @@ Connects and returns an `Organization` for `location`.
 | Name | Type | Description |  |  |
 | :--- | :--- | :--- | :--- | :--- |
 | `location` | `String` | The Ethereum address or ENS domain of an Aragon organization. |  |  |
-| `connector` | `Connector | [String, Object] | String` | Accepts a `Connector` instance, and either a string or a tuple for embedded connectors and their config. |  |  |
+| `connector` | `Connector \| [String, Object] \| String` | Accepts a `Connector` instance, and either a string or a tuple for embedded connectors and their config. |  |  |
 | `options` | `Object` | The optional configuration object. |  |  |
 | `options.readProvider` | `EthereumProvider` | An [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) compatible object. |  |  |
 | `options.chainId` | `Number` | The [Chain ID](https://chainid.network/) to connect to. Defaults to `1`. |  |  |
@@ -56,4 +56,3 @@ try {
   }
 }
 ```
-

--- a/docs/api-reference/connect.md
+++ b/docs/api-reference/connect.md
@@ -9,7 +9,7 @@ Connects and returns an `Organization` for `location`.
 | Name | Type | Description |  |  |
 | :--- | :--- | :--- | :--- | :--- |
 | `location` | `String` | The Ethereum address or ENS domain of an Aragon organization. |  |  |
-| `connector` | `Connector \| [String, Object] \| String` | Accepts a `Connector` instance, and either a string or a tuple for embedded connectors and their config. |  |  |
+| `connector` | `Connector or [String, Object] or String` | Accepts a `Connector` instance, and either a string or a tuple for embedded connectors and their config. |  |  |
 | `options` | `Object` | The optional configuration object. |  |  |
 | `options.readProvider` | `EthereumProvider` | An [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) compatible object. |  |  |
 | `options.chainId` | `Number` | The [Chain ID](https://chainid.network/) to connect to. Defaults to `1`. |  |  |

--- a/docs/guides/connect-with-react.md
+++ b/docs/guides/connect-with-react.md
@@ -74,7 +74,7 @@ This component is required in order to use the provided hooks.
 | Props | Type | Description |
 | :--- | :--- | :--- |
 | `location` | `String` | The Ethereum address or ENS domain of an Aragon organization. |
-| `connector` | `Connector \| [String, Object] \| String` | Accepts a `Connector` instance, and either a string or a tuple for embedded connectors and their config. |
+| `connector` | `Connector or [String, Object] or String` | Accepts a `Connector` instance, and either a string or a tuple for embedded connectors and their config. |
 | `options` | `Object` | The optional configuration object. |
 | `options.readProvider` | `EthereumProvider` | An [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) compatible object. |
 | `options.chainId` | `Number` | The [Chain ID](https://chainid.network/) to connect to. Defaults to `1`. |
@@ -83,7 +83,7 @@ This component is required in order to use the provided hooks.
 
 | Props | Type | Description |
 | :--- | :--- | :--- |
-| returns | `[Organization \| null, { loading: boolean, error: null \| Error, retry: Function }]` | An array containing the [organization](../api-reference/organization.md) and a loading status object. |
+| returns | `[Organization or null, { loading: boolean, error: null or Error, retry: Function }]` | An array containing the [organization](../api-reference/organization.md) and a loading status object. |
 
 ### useApp\(appFilters\)
 
@@ -92,7 +92,7 @@ This component is required in order to use the provided hooks.
 | `appFilter` | `String` or object \(optional\) | When a string is passed, the app will get searched by address if it starts by `0x`, and by `appName` otherwise. See `appFilter.address` and `appFilter.appName` to set them explicitly. For the time being, only one type of filter can get passed at a time. |
 | `appFilter.address` | `String` | Same as `appFilter`, but makes the selection by `address` explicit. |
 | `appFilter.appName` | `String` | Same as `appFilter`, but makes the selection by `appName` explicit. |
-| returns | `[App \| null, { loading:` `boolean, error: null \| Error, retry: Function }]` | An array containing a single [app](../api-reference/app.md) from the organization and a loading status object. |
+| returns | `[App or null, { loading:` `boolean, error: null or Error, retry: Function }]` | An array containing a single [app](../api-reference/app.md) from the organization and a loading status object. |
 
 ### useApps\(appFilters\)
 
@@ -101,10 +101,10 @@ This component is required in order to use the provided hooks.
 | `appFilter` | `String` or `String[]` or object \(optional\) | When a string is passed, apps will get filtered by address if it starts by `0x`, and by `appName` otherwise. When an array is passed, the first entry determines the type of filter. See `appFilter.address` and `appFilter.appName` to set them explicitly. For the time being, only one type of filter can get passed at a time. |
 | `appFilter.address` | `String` or `String[]` | Same as `appFilter`, but makes the selection by `address` explicit. |
 | `appFilter.appName` | `String` or `String[]` | Same as `appFilter`, but makes the selection by `appName` explicit. |
-| returns | `[App[], { loading: boolean, error: null \| Error, retry: Function }]` | An array containing the organization [apps](../api-reference/app.md) and a loading status object. |
+| returns | `[App[], { loading: boolean, error: null or Error, retry: Function }]` | An array containing the organization [apps](../api-reference/app.md) and a loading status object. |
 
 ### usePermissions\(\)
 
 | Name | Type | Description |  |
 | :--- | :--- | :--- | :--- |
-| returns | `[Permission[], { loading: boolean, error: null \| Error, retry: Function }]` | An array containing the organization [permissions](../api-reference/permission.md) and a loading status object. |  |
+| returns | `[Permission[], { loading: boolean, error: null or Error, retry: Function }]` | An array containing the organization [permissions](../api-reference/permission.md) and a loading status object. |  |

--- a/docs/guides/connect-with-react.md
+++ b/docs/guides/connect-with-react.md
@@ -74,7 +74,7 @@ This component is required in order to use the provided hooks.
 | Props | Type | Description |
 | :--- | :--- | :--- |
 | `location` | `String` | The Ethereum address or ENS domain of an Aragon organization. |
-| `connector` | `Connector | [String, Object] | String` | Accepts a `Connector` instance, and either a string or a tuple for embedded connectors and their config. |
+| `connector` | `Connector \| [String, Object] \| String` | Accepts a `Connector` instance, and either a string or a tuple for embedded connectors and their config. |
 | `options` | `Object` | The optional configuration object. |
 | `options.readProvider` | `EthereumProvider` | An [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) compatible object. |
 | `options.chainId` | `Number` | The [Chain ID](https://chainid.network/) to connect to. Defaults to `1`. |
@@ -83,7 +83,7 @@ This component is required in order to use the provided hooks.
 
 | Props | Type | Description |
 | :--- | :--- | :--- |
-| returns | `[Organization | null, { loading: boolean, error: null | Error, retry: Function }]` | An array containing the [organization](../api-reference/organization.md) and a loading status object. |
+| returns | `[Organization \| null, { loading: boolean, error: null \| Error, retry: Function }]` | An array containing the [organization](../api-reference/organization.md) and a loading status object. |
 
 ### useApp\(appFilters\)
 
@@ -92,7 +92,7 @@ This component is required in order to use the provided hooks.
 | `appFilter` | `String` or object \(optional\) | When a string is passed, the app will get searched by address if it starts by `0x`, and by `appName` otherwise. See `appFilter.address` and `appFilter.appName` to set them explicitly. For the time being, only one type of filter can get passed at a time. |
 | `appFilter.address` | `String` | Same as `appFilter`, but makes the selection by `address` explicit. |
 | `appFilter.appName` | `String` | Same as `appFilter`, but makes the selection by `appName` explicit. |
-| returns | `[App | null, { loading:` `boolean, error: null | Error, retry: Function }]` | An array containing a single [app](../api-reference/app.md) from the organization and a loading status object. |
+| returns | `[App \| null, { loading:` `boolean, error: null \| Error, retry: Function }]` | An array containing a single [app](../api-reference/app.md) from the organization and a loading status object. |
 
 ### useApps\(appFilters\)
 
@@ -101,11 +101,10 @@ This component is required in order to use the provided hooks.
 | `appFilter` | `String` or `String[]` or object \(optional\) | When a string is passed, apps will get filtered by address if it starts by `0x`, and by `appName` otherwise. When an array is passed, the first entry determines the type of filter. See `appFilter.address` and `appFilter.appName` to set them explicitly. For the time being, only one type of filter can get passed at a time. |
 | `appFilter.address` | `String` or `String[]` | Same as `appFilter`, but makes the selection by `address` explicit. |
 | `appFilter.appName` | `String` or `String[]` | Same as `appFilter`, but makes the selection by `appName` explicit. |
-| returns | `[App[], { loading: boolean, error: null | Error, retry: Function }]` | An array containing the organization [apps](../api-reference/app.md) and a loading status object. |
+| returns | `[App[], { loading: boolean, error: null \| Error, retry: Function }]` | An array containing the organization [apps](../api-reference/app.md) and a loading status object. |
 
 ### usePermissions\(\)
 
 | Name | Type | Description |  |
 | :--- | :--- | :--- | :--- |
-| returns | `[Permission[], { loading: boolean, error: null | Error, retry: Function }]` | An array containing the organization [permissions](../api-reference/permission.md) and a loading status object. |  |
-
+| returns | `[Permission[], { loading: boolean, error: null \| Error, retry: Function }]` | An array containing the organization [permissions](../api-reference/permission.md) and a loading status object. |  |


### PR DESCRIPTION
@bpierre I wonder if maybe we should use `or` as we did in a few places. 