### PR TITLE
Feat: Support xDai network provider and subgraph url

### DIFF
--- a/packages/connect-core/src/entities/Organization.ts
+++ b/packages/connect-core/src/entities/Organization.ts
@@ -4,6 +4,7 @@ import { AppFilters, AppFiltersParam, Network } from '@aragon/connect-types'
 import App from './App'
 import TransactionIntent from '../transactions/TransactionIntent'
 import Permission from './Permission'
+import { XDAI_WSS_ENDPOINT } from '../params'
 import { ConnectorInterface } from '../connections/ConnectorInterface'
 import { toArrayEntry } from '../utils/misc'
 
@@ -73,6 +74,8 @@ export default class Organization {
 
     this.#provider = provider
       ? getEthersProvider()
+      : network.chainId === 100
+      ? new ethers.providers.WebSocketProvider(XDAI_WSS_ENDPOINT, network)
       : ethers.getDefaultProvider(network)
 
     this._connector = connector

--- a/packages/connect-core/src/params.ts
+++ b/packages/connect-core/src/params.ts
@@ -1,1 +1,3 @@
 export const DEFAULT_IPFS_GATEWAY = 'https://ipfs.eth.aragon.network'
+
+export const XDAI_WSS_ENDPOINT = 'wss://xdai.poanetwork.dev/wss'

--- a/packages/connect-thegraph/src/connector.ts
+++ b/packages/connect-thegraph/src/connector.ts
@@ -28,6 +28,9 @@ function getOrgSubgraphUrl(network: Network): string | null {
   if (network.chainId === 4) {
     return 'https://api.thegraph.com/subgraphs/name/aragon/aragon-rinkeby'
   }
+  if (network.chainId === 100) {
+    return 'https://api.thegraph.com/subgraphs/name/1hive/aragon-xdai'
+  }
   return null
 }
 


### PR DESCRIPTION
This PR adds support for `xDai` default provider and subgraph URL.

Until now users need to use the library like: 

```tsx
const provider = new ethers.providers.JsonRpcProvider(
  'https://xdai.poanetwork.dev',
  {
    name: 'xdai',
    chainId: 100,
    ensAddress: '0xaafca6b0c89521752e559650206d7c925fd0e530',
  }
)

const org = await connect(
  daoAddress,
  [
    'thegraph',
    { orgSubgraphUrl: 'https://api.thegraph.com/subgraphs/name/1hive/aragon-xdai' },
  ],
  { chainId: 100, readProvider: ethereum }
)
```


With this change we can do:

```tsx
const org = await connect(ORG_ADDRESS, 'thegraph', {
  chainId: 100,
})
```