### PR TITLE
Fix: Add appId to repo query + fix typo on argument

### DIFF
--- a/packages/connect-thegraph/src/__test__/roles.test.ts
+++ b/packages/connect-thegraph/src/__test__/roles.test.ts
@@ -60,6 +60,11 @@ describe('when connecting to the mainnet subgraph', () => {
         expect(isAddress(role.manager!)).toBeTruthy()
       })
 
+      test('should have a valid name', () => {
+        expect(role.name).toBeDefined()
+        expect(role.name!.length).toBeGreaterThan(0)
+      })
+
       test('has a valid hash', () => {
         expect(isBytes32(role.hash)).toBeTruthy()
       })

--- a/packages/connect-thegraph/src/parsers/roles.ts
+++ b/packages/connect-thegraph/src/parsers/roles.ts
@@ -30,7 +30,7 @@ async function _parseRole(role: any, app: any, connector: any): Promise<Role> {
     grantees,
     appId: app.appId,
     artifact: app.version?.artifact,
-    contentUri: app?.contentUri,
+    contentUri: app.version?.contentUri,
   }
 
   return Role.create(roleData, connector)

--- a/packages/connect-thegraph/src/queries/index.ts
+++ b/packages/connect-thegraph/src/queries/index.ts
@@ -52,6 +52,7 @@ export const ORGANIZATION_PERMISSIONS = (type: Query) => gql`
 export const ROLE_BY_APP_ADDRESS = (type: Query) => gql`
   ${type} App($appAddress: String!) {
     app(id: $appAddress) {
+      appId
       version{
         ...Version_version
       }


### PR DESCRIPTION
Fix an issue during the creation of the `Repo` entity. When there is no artifact metadata on the subgraph available we try to manually fetch it using the `contentUri` attribute. With the changes made in the latest version (https://github.com/aragon/connect/pull/121), we introduced a regression bug pointing to the wrong data: `app.contentUri` -> `app.version.contentUri`.

