### PR TITLE
Add app installation count to `Repo` entity

### DIFF
--- a/packages/connect-thegraph/subgraph/schema.graphql
+++ b/packages/connect-thegraph/subgraph/schema.graphql
@@ -29,6 +29,8 @@ type Repo @entity {
   lastVersion: Version
   versions: [Version!]!
   registry: Registry! @derivedFrom(field: "repos")
+  "The number of proxies deployed for the app in this repo"
+  appCount: Int!
 }
 
 type Version @entity {

--- a/packages/connect-thegraph/subgraph/src/mappings/organization.ts
+++ b/packages/connect-thegraph/subgraph/src/mappings/organization.ts
@@ -85,6 +85,8 @@ export function handleNewProxyApp(event: NewAppProxyEvent): void {
         app.repo = repo.id
         app.repoName = repo.name
         app.repoAddress = repo.address
+	repo.appCount += 1
+	repo.save()
       }
     }
   }

--- a/packages/connect-thegraph/subgraph/src/mappings/registry.ts
+++ b/packages/connect-thegraph/subgraph/src/mappings/registry.ts
@@ -35,6 +35,7 @@ export function handleNewRepo(event: NewRepoEvent): void {
     repo.name = event.params.name
     repo.node = event.params.id
     repo.versions = []
+    repo.appCount = 0
   }
 
   // add the repo to the registry


### PR DESCRIPTION
This commit adds a metric that signifies the number of times an app has been installed.

I couldn't find a nice way to have a single "global" entity that could serve as a container for global metrics such as an overall organization count, so I opted to not implement that and resort to summing the `orgCount` properties of each organization factory in Apiary. If you have another idea I'd be glad to hear it 👍 

Closes #139 