### PR TITLE
Mark voting-disputable and agreements as private packages

### DIFF
--- a/packages/connect-agreement/package.json
+++ b/packages/connect-agreement/package.json
@@ -35,8 +35,8 @@
     "lint": "eslint --ext .ts ./src"
   },
   "dependencies": {
-    "@aragon/connect-core": "*",
-    "@aragon/connect-thegraph": "*",
+    "@aragon/connect-core": "^0.5.0",
+    "@aragon/connect-thegraph": "^0.5.0",
     "graphql-tag": "^2.10.3"
   },
   "devDependencies": {

--- a/packages/connect-agreement/package.json
+++ b/packages/connect-agreement/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aragon/connect-agreement",
   "version": "0.1.0",
+  "private": true,
   "license": "LGPL-3.0-or-later",
   "description": "Access and interact with Aragon Organizations and their apps.",
   "author": "Aragon Association <legal@aragon.org>",

--- a/packages/connect-voting-disputable/package.json
+++ b/packages/connect-voting-disputable/package.json
@@ -35,8 +35,8 @@
     "lint": "eslint --ext .ts ./src"
   },
   "dependencies": {
-    "@aragon/connect-core": "*",
-    "@aragon/connect-thegraph": "*",
+    "@aragon/connect-core": "^0.5.0",
+    "@aragon/connect-thegraph": "^0.5.0",
     "graphql-tag": "^2.10.3"
   },
   "devDependencies": {

--- a/packages/connect-voting-disputable/package.json
+++ b/packages/connect-voting-disputable/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aragon/connect-voting-disputable",
   "version": "0.1.0",
+  "private": true,
   "license": "LGPL-3.0-or-later",
   "description": "Access and interact with Aragon Organizations and their apps.",
   "author": "Aragon Association <legal@aragon.org>",


### PR DESCRIPTION
The `private` field will be removed whenever we feel their API is stable enough.

Also moved to fixed version ranges for the Connect packages.