### PR TITLE
createAppConnector(): stop using instanceof

### DIFF
--- a/packages/connect-core/src/utils/app-connectors.ts
+++ b/packages/connect-core/src/utils/app-connectors.ts
@@ -25,6 +25,15 @@ function normalizeConnectorConfig<Config extends object>(
   throw new Error('The connector should be passed as a string or an array.')
 }
 
+// Check if an app is valid. We are not using instanceof here, because the
+// passed app might come from the final app dependency, while @connect-core
+// might come from the app connector they are using, with two different
+// versions. It also makes it easier to work with linked dependencies, as it
+// creates the same kind of issues.
+function isAppValid(app: any): boolean {
+  return app && app.name && app.address && app.appId && app.version
+}
+
 export function createAppConnector<
   ConnectedApp extends object,
   Config extends object
@@ -39,8 +48,10 @@ export function createAppConnector<
   ): Promise<App & ConnectedApp> {
     app = await app
 
-    if (!(app instanceof App)) {
-      throw new Error(`App connector: the passed value is not an App.`)
+    if (!isAppValid(app)) {
+      throw new Error(
+        `App connector: the passed value doesn’t appear to be an App.`
+      )
     }
 
     const { connection } = app.organization


### PR DESCRIPTION
The app instance passed to `createAppConnector()` might come from the a version of `@aragon/connect-core` that is a dependent of `@aragon/connect`, which is generally included as a direct dependency by the final app.

`createAppConnector()` itself comes from the app connector package, which might contain a different version of `@aragon/connect-core`.

These situations make the use of `typeof` impossible, as two `App` constructors would come from the two different modules.

There are also other situations where linking one dependency (e.g. the app connector only) can create the same issue.

This commits moves to duck typing to validate the App instance, which also make it work in these different scenarios.