### PR TITLE
Replace GraphQL subscriptions by queries + polling

### DIFF
--- a/examples/bundler-parcel/.gitignore
+++ b/examples/bundler-parcel/.gitignore
@@ -1,0 +1,2 @@
+dist/
+.cache/

--- a/examples/bundler-parcel/package.json
+++ b/examples/bundler-parcel/package.json
@@ -1,17 +1,18 @@
 {
-  "name": "minimal-setup-web",
+  "name": "bundler-parcel",
   "private": true,
   "version": "0.5.3",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "parcel index.html",
-    "build": "parcel build index.html"
+    "start": "parcel src/index.html",
+    "build": "parcel build src/index.html"
   },
   "dependencies": {
     "@aragon/connect-react": "^0.5.3",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "string.ify": "^1.0.64"
   },
   "devDependencies": {
     "parcel": "^1.12.4"

--- a/examples/bundler-parcel/src/index.html
+++ b/examples/bundler-parcel/src/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <title>bundler-parcel</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
   </head>
   <body>
-    <div id="app"></div>
-    <script src="index.js"></script>
+    Please open the console
   </body>
 </html>

--- a/examples/bundler-parcel/src/index.js
+++ b/examples/bundler-parcel/src/index.js
@@ -1,0 +1,5 @@
+import connect from '@aragon/connect'
+
+connect('a1.aragonid.eth', 'thegraph').then((org) => {
+  console.log('Organization:', org)
+})

--- a/examples/bundler-webpack-ts-loader/package.json
+++ b/examples/bundler-webpack-ts-loader/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "org-viewer-react",
+  "name": "bundler-webpack-ts-loader",
+  "main": "dist/index.js",
   "version": "0.5.3",
   "private": true,
+  "sideEffects": false,
   "scripts": {
     "start": "yarn clean && webpack-dev-server",
-    "build": "yarn clean && webpack --production",
-    "build:stats": "yarn clean && webpack --env production --json > webpack-stats.json",
+    "build": "yarn clean && webpack --env production",
     "clean": "rm -rf ./dist ./tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@aragon/connect-react": "^0.5.3",
-    "@emotion/core": "^10.0.28",
+    "@aragon/connect": "^0.5.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },
@@ -21,7 +21,6 @@
     "ts-loader": "^7.0.2",
     "typescript": "^3.8.3",
     "webpack": "^4.44.1",
-    "webpack-bundle-analyzer": "^3.8.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3"
   }

--- a/examples/bundler-webpack-ts-loader/src/index.html
+++ b/examples/bundler-webpack-ts-loader/src/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <title>bundler-webpack-ts-loader</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
   </head>
   <body>
-    <div id="app"></div>
-    <script src="index.js"></script>
+    Please open the console
   </body>
 </html>

--- a/examples/bundler-webpack-ts-loader/src/index.tsx
+++ b/examples/bundler-webpack-ts-loader/src/index.tsx
@@ -1,0 +1,5 @@
+import connect from '@aragon/connect'
+
+connect('a1.aragonid.eth', 'thegraph').then((org) => {
+  console.log('Organization:', org)
+})

--- a/examples/bundler-webpack-ts-loader/tsconfig.json
+++ b/examples/bundler-webpack-ts-loader/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "src",
+    "jsx": "react"
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/examples/bundler-webpack-ts-loader/webpack.config.js
+++ b/examples/bundler-webpack-ts-loader/webpack.config.js
@@ -1,7 +1,5 @@
 const path = require('path')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
-  .BundleAnalyzerPlugin
 
 module.exports = {
   entry: './src/index.tsx',
@@ -34,8 +32,5 @@ module.exports = {
     contentBase: path.join(__dirname, 'dist'),
     port: 1234,
   },
-  plugins: [
-    ...(process.env.BUNDLE_STATS === '1' ? [new BundleAnalyzerPlugin()] : []),
-    new HtmlWebpackPlugin({ title: 'Org Viewer' }),
-  ],
+  plugins: [new HtmlWebpackPlugin({ template: './src/index.html' })],
 }

--- a/examples/list-balances-cli/src/index.ts
+++ b/examples/list-balances-cli/src/index.ts
@@ -8,18 +8,18 @@ const RESET = '\x1b[0m'
 const DECIMALS = 18
 
 const env = {
-  chainId: parseInt(process.env.CHAIN_ID ?? '1', 10),
+  network: parseInt(process.env.CHAIN_ID ?? '1', 10),
   location: process.env.ORGANIZATION ?? 'piedao.aragonid.eth',
 }
 
 async function main() {
-  const org = await connect(env.location, 'thegraph', { chainId: env.chainId })
+  const org = await connect(env.location, 'thegraph', { network: env.network })
   const tokens = await connectTokens(org.app('token-manager'))
   const token = await tokens.token()
   const holders = await tokens.holders()
 
   printOrganization(org)
-  printBalances(holders, await token.symbol)
+  printBalances(holders, token.symbol)
 }
 
 function printOrganization(organization: any): void {

--- a/examples/list-votes-cli/src/index.ts
+++ b/examples/list-votes-cli/src/index.ts
@@ -11,7 +11,7 @@ const env = {
 
 async function main() {
   const org = await connect(env.location, 'thegraph', { network: env.network })
-  const voting = await connectVoting(org.app('tsateiurteiuart'))
+  const voting = await connectVoting(org.app('voting'))
   const votes = await voting.votes()
 
   printOrganization(org)

--- a/examples/nodejs/src/describe-script.ts
+++ b/examples/nodejs/src/describe-script.ts
@@ -1,5 +1,5 @@
 import { connect, describeScript, App } from '@aragon/connect'
-import { Vote, Voting } from '@aragon/connect-voting'
+import connectVoting, { Vote } from '@aragon/connect-voting'
 
 const VOTING_SUBGRAPH_URL =
   'https://api.thegraph.com/subgraphs/name/aragon/aragon-voting-mainnet'
@@ -14,10 +14,7 @@ function voteId(vote: Vote) {
 async function main() {
   const org = await connect('beehive.aragonid.eth', 'thegraph')
   const apps = await org.apps()
-  const votingApp = apps.find((app: App) => app.name === 'voting')!
-
-  const voting = new Voting(votingApp.address, VOTING_SUBGRAPH_URL)
-
+  const voting = await connectVoting(org.app('voting'))
   const votes = await voting.votes()
 
   const { script } = votes.find((vote) => voteId(vote) === '#54')!

--- a/examples/nodejs/src/organization.ts
+++ b/examples/nodejs/src/organization.ts
@@ -10,7 +10,7 @@ async function main() {
   permissions.map(console.log)
 
   console.log('\nA role from a permission:')
-  const role = await permissions[4].getRole()
+  const role = await permissions[4].role()
   console.log(role)
 
   console.log('\nApps:')
@@ -34,7 +34,7 @@ async function main() {
   console.log(appByAddress)
 
   console.log('\nAn app from a permission:')
-  const appFromPermission = await permissions[1].getApp()
+  const appFromPermission = await permissions[1].app()
   console.log(appFromPermission)
 }
 

--- a/examples/nodejs/src/subscriptions-org.ts
+++ b/examples/nodejs/src/subscriptions-org.ts
@@ -5,7 +5,7 @@ const ORG_ADDRESS = '0xd697d1f417c621a6a54d9a7fa2805596ca393222'
 
 async function main() {
   const org = (await connect(ORG_ADDRESS, 'thegraph', {
-    chainId: 4,
+    network: 4,
   })) as Organization
 
   const subscription = org.onPermissions((permissions: Permission[]) => {

--- a/examples/nodejs/src/subscriptions-tokens.ts
+++ b/examples/nodejs/src/subscriptions-tokens.ts
@@ -1,25 +1,24 @@
-import { TokenManager, TokenHolder } from '@aragon/connect-tokens'
+import connect from '@aragon/connect'
+import connectTokens, { TokenHolder } from '@aragon/connect-tokens'
 import { keepRunning } from './helpers'
 
+const ORG_ADDRESS = '0x7318f8bc0a9f0044d5c77a6aca9c73c1da49c51e'
 const TOKENS_APP_ADDRESS = '0xb27004bf714ce2aa38f14647b38836f26df86cbf'
-const ALL_TOKEN_MANAGER_SUBGRAPH_URL =
-  'https://api.thegraph.com/subgraphs/name/aragon/aragon-tokens-mainnet'
 
 async function main() {
-  const tokenManager = new TokenManager(
-    TOKENS_APP_ADDRESS,
-    ALL_TOKEN_MANAGER_SUBGRAPH_URL
-  )
+  const org = await connect(ORG_ADDRESS, 'thegraph')
+  const tokens = await connectTokens(org.app(TOKENS_APP_ADDRESS))
+  const token = await tokens.token()
 
-  const token = await tokenManager.token()
+  console.log(`\nToken:`)
   console.log(token)
 
-  const subscription = token.onHolders((holders: TokenHolder[]) => {
+  const subscription = tokens.onHolders((holders: TokenHolder[]) => {
     console.log(`\nHolders:`)
     holders.map(console.log)
   })
 
-  await keepRunning()
+  // await keepRunning()
 
   // Simply to illustrate how to close a subscription
   subscription.unsubscribe()

--- a/examples/nodejs/src/subscriptions-voting.ts
+++ b/examples/nodejs/src/subscriptions-voting.ts
@@ -1,15 +1,15 @@
-import { Voting, Vote, Cast } from '@aragon/connect-voting'
+import connect from '@aragon/connect'
+import connectVoting, { Voting, Vote, Cast } from '@aragon/connect-voting'
 import { keepRunning } from './helpers'
 
 const ORG_ADDRESS = '0x7cee20f778a53403d4fc8596e88deb694bc91c98'
 const VOTING_APP_ADDRESS = '0xf7f9a33ed13b01324884bd87137609251b5f7c88'
-const ALL_VOTING_SUBGRAPH_URL =
-  'https://api.thegraph.com/subgraphs/name/aragon/aragon-voting-rinkeby'
 
 async function main() {
-  const voting = new Voting(VOTING_APP_ADDRESS, ALL_VOTING_SUBGRAPH_URL)
+  const org = await connect(ORG_ADDRESS, 'thegraph', { network: 4 })
+  const voting = await connectVoting(org.app(VOTING_APP_ADDRESS))
 
-  const votesSubscription = voting.onVotes((votes: Vote[]) => {
+  const votesSubscription = voting.onVotes({}, (votes: Vote[]) => {
     console.log('\nVotes: ')
     votes.map(console.log)
     console.log(

--- a/examples/nodejs/src/subscriptions-voting.ts
+++ b/examples/nodejs/src/subscriptions-voting.ts
@@ -11,7 +11,15 @@ async function main() {
 
   const votesSubscription = voting.onVotes({}, (votes: Vote[]) => {
     console.log('\nVotes: ')
-    votes.map(console.log)
+    votes
+      .map((vote, index) => ({
+        index,
+        title: vote.metadata,
+        id: vote.id,
+      }))
+      .forEach((vote) => {
+        console.log(vote)
+      })
     console.log(
       `\nTry creating a new vote at https://rinkeby.aragon.org/#/${ORG_ADDRESS}/${VOTING_APP_ADDRESS}/\n`
     )
@@ -23,7 +31,9 @@ async function main() {
 
   const castsSubscription = vote1.onCasts((casts: Cast[]) => {
     console.log(`\nCasts:`)
-    casts.map(console.log)
+    casts.forEach((cast) => {
+      console.log(cast)
+    })
     console.log(
       `\nTry casting a vote on https://rinkeby.aragon.org/#/${ORG_ADDRESS}/${VOTING_APP_ADDRESS}/vote/1 (You must first mint yourself a token in the Token Manager)\n`
     )

--- a/examples/nodejs/src/tokens.ts
+++ b/examples/nodejs/src/tokens.ts
@@ -1,23 +1,19 @@
-import { TokenManager } from '@aragon/connect-tokens'
+import connect from '@aragon/connect'
+import connectTokens from '@aragon/connect-tokens'
 
+const ORG_ADDRESS = '0x7318f8bc0a9f0044d5c77a6aca9c73c1da49c51e'
 const TOKENS_APP_ADDRESS = '0xb27004bf714ce2aa38f14647b38836f26df86cbf'
-const ALL_TOKEN_MANAGER_SUBGRAPH_URL =
-  'https://api.thegraph.com/subgraphs/name/aragon/aragon-tokens-mainnet'
 
 async function main() {
-  const tokenManager = new TokenManager(
-    TOKENS_APP_ADDRESS,
-    ALL_TOKEN_MANAGER_SUBGRAPH_URL,
-    true
-  )
+  const org = await connect(ORG_ADDRESS, 'thegraph', { verbose: true })
+  const tokens = await connectTokens(org.app(TOKENS_APP_ADDRESS))
 
-  console.log(tokenManager)
-
-  const token = await tokenManager.token()
+  const token = await tokens.token()
   console.log(token)
 
   console.log('\nHolders:')
-  const holders = await token.holders()
+  const holders = await tokens.holders()
+
   holders.map(console.log)
 }
 

--- a/examples/nodejs/src/voting.ts
+++ b/examples/nodejs/src/voting.ts
@@ -1,18 +1,18 @@
 import { connect } from '@aragon/connect'
-import { Cast, Vote, Voting } from '@aragon/connect-voting'
+import connectVoting, { Cast, Vote, Voting } from '@aragon/connect-voting'
 
-type Env = { chainId: number; org: string; votingSubgraphUrl: string }
+type Env = { network: number; org: string; votingSubgraphUrl: string }
 
 const envs = new Map(
   Object.entries({
     rinkeby: {
-      chainId: 4,
+      network: 4,
       org: 'gardens.aragonid.eth',
       votingSubgraphUrl:
         'https://api.thegraph.com/subgraphs/name/aragon/aragon-voting-rinkeby',
     },
     mainnet: {
-      chainId: 1,
+      network: 1,
       org: 'governance.aragonproject.eth',
       votingSubgraphUrl:
         'https://api.thegraph.com/subgraphs/name/aragon/aragon-voting-mainnet',
@@ -41,20 +41,11 @@ function voteId(vote: Vote) {
 }
 
 async function main() {
-  const org = await connect(env.org, 'thegraph', { chainId: env.chainId })
-  const apps = await org.apps()
-  const votingApp = apps.find((app) => app.appName === 'voting.aragonpm.eth')
+  const org = await connect(env.org, 'thegraph', { network: env.network })
+  const voting = await connectVoting(org.app('voting'))
 
   console.log('\nOrganization:', org.location, `(${org.address})`)
-
-  if (!votingApp?.address) {
-    console.log('\nNo voting app found in this organization')
-    return
-  }
-
-  console.log(`\nVoting app: ${votingApp.address}`)
-
-  const voting = new Voting(votingApp.address, env.votingSubgraphUrl)
+  console.log(`\nVoting app: ${voting.address}`)
 
   console.log(`\nVotes:`)
   const votes = await voting.votes()

--- a/examples/nodejs/tsconfig.json
+++ b/examples/nodejs/tsconfig.json
@@ -8,7 +8,7 @@
   "references": [
     { "path": "../../packages/connect" },
     { "path": "../../packages/connect-thegraph" },
-    { "path": "../../packages/connect-thegraph-tokens" },
-    { "path": "../../packages/connect-thegraph-voting" }
+    { "path": "../../packages/connect-tokens" },
+    { "path": "../../packages/connect-voting" }
   ]
 }

--- a/examples/org-viewer-react/src/App.tsx
+++ b/examples/org-viewer-react/src/App.tsx
@@ -13,8 +13,8 @@ export default function App() {
   return (
     <Connect
       location={filterOrgName(orgName)}
-      connector={['thegraph', { orgSubgraphUrl: env.orgSubgraphUrl }]}
-      options={{ chainId: env.chainId }}
+      connector="thegraph"
+      options={{ network: env.chainId }}
     >
       <Main>
         <OrgInput onChange={openOrg} orgName={orgName} />

--- a/examples/org-viewer-react/src/environment.ts
+++ b/examples/org-viewer-react/src/environment.ts
@@ -1,7 +1,6 @@
 type EnvType = {
   addresses: string[]
   chainId: number
-  orgSubgraphUrl?: string
 }
 
 const ENV_NAME = 'mainnet'
@@ -22,8 +21,6 @@ const ENVIRONMENTS = new Map([
     'mainnet_staging',
     {
       chainId: 1,
-      orgSubgraphUrl:
-        'https://api.thegraph.com/subgraphs/name/aragon/aragon-mainnet-staging',
       addresses: ['piedao.aragonid.eth'],
     },
   ],

--- a/examples/org-viewer-web/package.json
+++ b/examples/org-viewer-web/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "sideEffects": false,
   "scripts": {
-    "dev": "yarn clean && webpack-dev-server",
+    "start": "yarn clean && webpack-dev-server",
     "build": "yarn clean && NODE_ENV=production webpack",
     "build:stats": "yarn clean && webpack --env production --json > webpack-stats.json",
     "clean": "rm -rf ./dist ./tsconfig.tsbuildinfo",
@@ -14,16 +14,16 @@
   "dependencies": {
     "@aragon/connect": "^0.5.3",
     "@emotion/core": "^10.0.28",
-    "@types/react": "^16.9.35",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },
   "devDependencies": {
+    "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.8",
     "html-webpack-plugin": "^4.3.0",
     "ts-loader": "^7.0.2",
     "typescript": "^3.8.3",
-    "webpack": "^5.0.0-beta.15",
+    "webpack": "^4.44.1",
     "webpack-bundle-analyzer": "^3.8.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3"

--- a/examples/org-viewer-web/src/App.tsx
+++ b/examples/org-viewer-web/src/App.tsx
@@ -51,11 +51,7 @@ export default function App() {
 
   const [org = null, loading] = useCancellableAsync(
     async () =>
-      connect(
-        filterOrgName(orgName),
-        ['thegraph', { orgSubgraphUrl: env.orgSubgraphUrl }],
-        { chainId: env.chainId }
-      ),
+      connect(filterOrgName(orgName), 'thegraph', { network: env.chainId }),
     [orgName]
   )
 

--- a/examples/org-viewer-web/src/environment.ts
+++ b/examples/org-viewer-web/src/environment.ts
@@ -1,7 +1,6 @@
 type EnvType = {
   addresses: string[]
   chainId: number
-  orgSubgraphUrl?: string
 }
 
 const ENV_NAME = 'mainnet'
@@ -16,15 +15,6 @@ const ENVIRONMENTS = new Map([
         'governance.aragonproject.eth',
         'brightid.aragonid.eth',
       ],
-    },
-  ],
-  [
-    'mainnet_staging',
-    {
-      chainId: 1,
-      orgSubgraphUrl:
-        'https://api.thegraph.com/subgraphs/name/aragon/aragon-mainnet-staging',
-      addresses: ['piedao.aragonid.eth'],
     },
   ],
   [

--- a/examples/org-viewer-web/webpack.config.js
+++ b/examples/org-viewer-web/webpack.config.js
@@ -8,9 +8,6 @@ module.exports = {
   devtool: 'inline-source-map',
   target: 'web',
   mode: process.env.NODE_ENV || 'development',
-  stats: {
-    preset: process.env.NODE_ENV === 'production' ? 'errors-only' : 'normal',
-  },
   module: {
     rules: [
       {
@@ -27,7 +24,7 @@ module.exports = {
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
-    mainFields: ['module', 'browser', 'main'],
+    mainFields: ['main', 'module', 'browser'],
   },
   output: {
     filename: 'bundle.js',

--- a/packages/connect-agreement/src/__test__/connector/agreement.test.ts
+++ b/packages/connect-agreement/src/__test__/connector/agreement.test.ts
@@ -9,7 +9,9 @@ describe('Agreement', () => {
   let connector: AgreementConnectorTheGraph
 
   beforeAll(() => {
-    connector = new AgreementConnectorTheGraph(AGREEMENT_SUBGRAPH_URL)
+    connector = new AgreementConnectorTheGraph({
+      subgraphUrl: AGREEMENT_SUBGRAPH_URL,
+    })
   })
 
   afterAll(async () => {

--- a/packages/connect-agreement/src/__test__/connector/signers.test.ts
+++ b/packages/connect-agreement/src/__test__/connector/signers.test.ts
@@ -9,7 +9,9 @@ describe('Agreement signers', () => {
   let connector: AgreementConnectorTheGraph
 
   beforeAll(() => {
-    connector = new AgreementConnectorTheGraph(AGREEMENT_SUBGRAPH_URL)
+    connector = new AgreementConnectorTheGraph({
+      subgraphUrl: AGREEMENT_SUBGRAPH_URL,
+    })
   })
 
   afterAll(async () => {

--- a/packages/connect-agreement/src/__test__/connector/versions.test.ts
+++ b/packages/connect-agreement/src/__test__/connector/versions.test.ts
@@ -8,7 +8,9 @@ describe('Agreement versions', () => {
   let connector: AgreementConnectorTheGraph
 
   beforeAll(() => {
-    connector = new AgreementConnectorTheGraph(AGREEMENT_SUBGRAPH_URL)
+    connector = new AgreementConnectorTheGraph({
+      subgraphUrl: AGREEMENT_SUBGRAPH_URL,
+    })
   })
 
   afterAll(async () => {

--- a/packages/connect-agreement/src/__test__/entities/agreement.test.ts
+++ b/packages/connect-agreement/src/__test__/entities/agreement.test.ts
@@ -8,7 +8,9 @@ describe('Agreement', () => {
   let agreement: Agreement
 
   beforeAll(() => {
-    const connector = new AgreementConnectorTheGraph(AGREEMENT_SUBGRAPH_URL)
+    const connector = new AgreementConnectorTheGraph({
+      subgraphUrl: AGREEMENT_SUBGRAPH_URL,
+    })
     agreement = new Agreement(connector, AGREEMENT_APP_ADDRESS)
   })
 

--- a/packages/connect-agreement/src/connect.ts
+++ b/packages/connect-agreement/src/connect.ts
@@ -26,9 +26,12 @@ export default createAppConnector<Agreement, Config>(
         config?.pollInterval ?? orgConnector.config?.pollInterval ?? undefined
     }
 
-    return new Agreement(
-      new AgreementConnectorTheGraph({ pollInterval, subgraphUrl, verbose }),
-      app.address
-    )
+    const connectorTheGraph = new AgreementConnectorTheGraph({
+      pollInterval,
+      subgraphUrl,
+      verbose,
+    })
+
+    return new Agreement(connectorTheGraph, app.address)
   }
 )

--- a/packages/connect-agreement/src/connect.ts
+++ b/packages/connect-agreement/src/connect.ts
@@ -1,16 +1,16 @@
 import { createAppConnector } from '@aragon/connect-core'
-
 import Agreement from './models/Agreement'
 import AgreementConnectorTheGraph, {
   subgraphUrlFromChainId,
 } from './thegraph/connector'
 
 type Config = {
-  subgraphUrl: string
+  pollInterval?: number
+  subgraphUrl?: string
 }
 
 export default createAppConnector<Agreement, Config>(
-  ({ app, config, connector, network, verbose }) => {
+  ({ app, config, connector, network, orgConnector, verbose }) => {
     if (connector !== 'thegraph') {
       console.warn(
         `Connector unsupported: ${connector}. Using "thegraph" instead.`
@@ -18,11 +18,17 @@ export default createAppConnector<Agreement, Config>(
     }
 
     const subgraphUrl =
-      config.subgraphUrl ?? subgraphUrlFromChainId(network.chainId)
-    const agreementConnector = new AgreementConnectorTheGraph(
-      subgraphUrl,
-      verbose
+      config.subgraphUrl ?? subgraphUrlFromChainId(network.chainId) ?? undefined
+
+    let pollInterval
+    if (orgConnector.name === 'thegraph') {
+      pollInterval =
+        config?.pollInterval ?? orgConnector.config?.pollInterval ?? undefined
+    }
+
+    return new Agreement(
+      new AgreementConnectorTheGraph({ pollInterval, subgraphUrl, verbose }),
+      app.address
     )
-    return new Agreement(agreementConnector, app.address)
   }
 )

--- a/packages/connect-agreement/src/thegraph/connector.ts
+++ b/packages/connect-agreement/src/thegraph/connector.ts
@@ -28,16 +28,25 @@ export function subgraphUrlFromChainId(chainId: number) {
   return null
 }
 
+type AgreementConnectorTheGraphConfig = {
+  pollInterval?: number
+  subgraphUrl?: string
+  verbose?: boolean
+}
+
 export default class AgreementConnectorTheGraph implements IAgreementConnector {
   #gql: GraphQLWrapper
 
-  constructor(subgraphUrl: string, verbose: boolean = false) {
-    if (!subgraphUrl) {
+  constructor(config: AgreementConnectorTheGraphConfig) {
+    if (!config.subgraphUrl) {
       throw new Error(
         'AgreementConnectorTheGraph requires subgraphUrl to be passed.'
       )
     }
-    this.#gql = new GraphQLWrapper(subgraphUrl, verbose)
+    this.#gql = new GraphQLWrapper(config.subgraphUrl, {
+      pollInterval: config.pollInterval,
+      verbose: config.verbose,
+    })
   }
 
   async disconnect() {

--- a/packages/connect-agreement/src/thegraph/queries/index.ts
+++ b/packages/connect-agreement/src/thegraph/queries/index.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 export const GET_AGREEMENT = (type: string) => gql`
-  ${type} Agreement($agreement: String!) {
+  query Agreement($agreement: String!) {
     agreement(id: $agreement) {
       id
       dao
@@ -14,7 +14,7 @@ export const GET_AGREEMENT = (type: string) => gql`
 `
 
 export const GET_CURRENT_VERSION = (type: string) => gql`  
-  ${type} Agreement($agreement: String!) {
+  query Agreement($agreement: String!) {
     agreement(id: $agreement) {
       currentVersion {
         id
@@ -30,7 +30,7 @@ export const GET_CURRENT_VERSION = (type: string) => gql`
 `
 
 export const GET_VERSION = (type: string) => gql`  
-  ${type} Version($versionId: String!) {
+  query Version($versionId: String!) {
     version(id: $versionId) {
       id
       versionId
@@ -44,7 +44,7 @@ export const GET_VERSION = (type: string) => gql`
 `
 
 export const ALL_VERSIONS = (type: string) => gql`
-  ${type} Versions($agreement: String!, $first: Int!, $skip: Int!) {
+  query Versions($agreement: String!, $first: Int!, $skip: Int!) {
     versions(where: {
       agreement: $agreement
     }, first: $first, skip: $skip) {
@@ -60,7 +60,7 @@ export const ALL_VERSIONS = (type: string) => gql`
 `
 
 export const GET_SIGNER = (type: string) => gql`
-  ${type} Signer($signerId: String!) {
+  query Signer($signerId: String!) {
     signer(id: $signerId) {
       id
       address
@@ -70,7 +70,7 @@ export const GET_SIGNER = (type: string) => gql`
 `
 
 export const GET_SIGNATURES = (type: string) => gql`
-  ${type} Signatures($signerId: String!, $first: Int!, $skip: Int!) {
+  query Signatures($signerId: String!, $first: Int!, $skip: Int!) {
     signatures(where: { 
       signer: $signerId
     }, first: $first, skip: $skip) {

--- a/packages/connect-agreement/src/thegraph/queries/index.ts
+++ b/packages/connect-agreement/src/thegraph/queries/index.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 export const GET_AGREEMENT = (type: string) => gql`
-  query Agreement($agreement: String!) {
+  ${type} Agreement($agreement: String!) {
     agreement(id: $agreement) {
       id
       dao
@@ -14,7 +14,7 @@ export const GET_AGREEMENT = (type: string) => gql`
 `
 
 export const GET_CURRENT_VERSION = (type: string) => gql`  
-  query Agreement($agreement: String!) {
+  ${type} Agreement($agreement: String!) {
     agreement(id: $agreement) {
       currentVersion {
         id
@@ -30,7 +30,7 @@ export const GET_CURRENT_VERSION = (type: string) => gql`
 `
 
 export const GET_VERSION = (type: string) => gql`  
-  query Version($versionId: String!) {
+  ${type} Version($versionId: String!) {
     version(id: $versionId) {
       id
       versionId
@@ -44,7 +44,7 @@ export const GET_VERSION = (type: string) => gql`
 `
 
 export const ALL_VERSIONS = (type: string) => gql`
-  query Versions($agreement: String!, $first: Int!, $skip: Int!) {
+  ${type} Versions($agreement: String!, $first: Int!, $skip: Int!) {
     versions(where: {
       agreement: $agreement
     }, first: $first, skip: $skip) {
@@ -60,7 +60,7 @@ export const ALL_VERSIONS = (type: string) => gql`
 `
 
 export const GET_SIGNER = (type: string) => gql`
-  query Signer($signerId: String!) {
+  ${type} Signer($signerId: String!) {
     signer(id: $signerId) {
       id
       address
@@ -70,7 +70,7 @@ export const GET_SIGNER = (type: string) => gql`
 `
 
 export const GET_SIGNATURES = (type: string) => gql`
-  query Signatures($signerId: String!, $first: Int!, $skip: Int!) {
+  ${type} Signatures($signerId: String!, $first: Int!, $skip: Int!) {
     signatures(where: { 
       signer: $signerId
     }, first: $first, skip: $skip) {

--- a/packages/connect-core/src/connections/ConnectorJson.ts
+++ b/packages/connect-core/src/connections/ConnectorJson.ts
@@ -19,13 +19,15 @@ export type ConnectorJsonConfig = {
 
 class ConnectorJson implements IOrganizationConnector {
   #permissions: Permission[]
+  connection?: ConnectionContext
+  readonly config: ConnectorJsonConfig
   readonly name = 'json'
   readonly network: Network
-  connection?: ConnectionContext
 
-  constructor({ permissions, network }: ConnectorJsonConfig) {
-    this.#permissions = permissions
-    this.network = network
+  constructor(config: ConnectorJsonConfig) {
+    this.config = config
+    this.network = config.network
+    this.#permissions = config.permissions
   }
 
   async connect(connection: ConnectionContext) {

--- a/packages/connect-core/src/connections/IOrganizationConnector.ts
+++ b/packages/connect-core/src/connections/IOrganizationConnector.ts
@@ -9,6 +9,7 @@ import Role from '../entities/Role'
 export default interface IOrganizationConnector {
   readonly name: string
   readonly network: Network
+  readonly config: any
   appByAddress(organization: Organization, appAddress: string): Promise<App>
   appForOrg(organization: Organization, filters?: AppFilters): Promise<App>
   appsForOrg(organization: Organization, filters?: AppFilters): Promise<App[]>

--- a/packages/connect-core/src/connections/IOrganizationConnector.ts
+++ b/packages/connect-core/src/connections/IOrganizationConnector.ts
@@ -9,7 +9,7 @@ import Role from '../entities/Role'
 export default interface IOrganizationConnector {
   readonly name: string
   readonly network: Network
-  readonly config: any
+  readonly config: { [key: string]: any }
   appByAddress(organization: Organization, appAddress: string): Promise<App>
   appForOrg(organization: Organization, filters?: AppFilters): Promise<App>
   appsForOrg(organization: Organization, filters?: AppFilters): Promise<App[]>

--- a/packages/connect-core/src/utils/app-connectors.ts
+++ b/packages/connect-core/src/utils/app-connectors.ts
@@ -4,10 +4,11 @@ import App from '../entities/App'
 
 type AppConnectContext = {
   app: App
-  connector: string
   config: object
+  connector: string
   ipfs: ConnectionContext['ipfs']
   network: Network
+  orgConnector: ConnectionContext['orgConnector']
   verbose: boolean
 }
 
@@ -56,7 +57,12 @@ export function createAppConnector<
 
     const { connection } = app.organization
     const { orgConnector } = connection
+
+    // App connector config.
     const [connectorName, connectorConfig] = normalizeConnectorConfig<Config>(
+      // Contrary to the main connect() function, app connectors don’t require
+      // the connector to be passed. In this case, the name of the org
+      // connector (e.g. `name`) is used instead.
       connector || orgConnector.name
     )
 
@@ -66,6 +72,7 @@ export function createAppConnector<
       connector: connectorName,
       ipfs: connection.ipfs,
       network: orgConnector.network,
+      orgConnector,
       verbose: connection.verbose,
     })
 

--- a/packages/connect-ethereum/src/index.ts
+++ b/packages/connect-ethereum/src/index.ts
@@ -19,11 +19,13 @@ export type ConnectorEthereumConfig = {
 }
 
 class ConnectorEthereum implements IOrganizationConnector {
+  connection?: ConnectionContext
+  readonly config: ConnectorEthereumConfig
   readonly name = 'ethereum'
   readonly network: Network
-  connection?: ConnectionContext
 
   constructor(config: ConnectorEthereumConfig) {
+    this.config = config
     this.network = config.network
   }
 

--- a/packages/connect-finance/src/__test__/token-balance.test.ts
+++ b/packages/connect-finance/src/__test__/token-balance.test.ts
@@ -11,7 +11,9 @@ describe('when connecting to a finance app', () => {
   let connector: FinanceConnectorTheGraph
 
   beforeAll(() => {
-    connector = new FinanceConnectorTheGraph(FINANCE_SUBGRAPH_URL)
+    connector = new FinanceConnectorTheGraph({
+      subgraphUrl: FINANCE_SUBGRAPH_URL,
+    })
   })
 
   afterAll(async () => {

--- a/packages/connect-finance/src/__test__/transactions.test.ts
+++ b/packages/connect-finance/src/__test__/transactions.test.ts
@@ -9,7 +9,9 @@ describe('when connecting to a finance app', () => {
   let connector: FinanceConnectorTheGraph
 
   beforeAll(() => {
-    connector = new FinanceConnectorTheGraph(FINANCE_SUBGRAPH_URL)
+    connector = new FinanceConnectorTheGraph({
+      subgraphUrl: FINANCE_SUBGRAPH_URL,
+    })
   })
 
   afterAll(async () => {

--- a/packages/connect-finance/src/connect.ts
+++ b/packages/connect-finance/src/connect.ts
@@ -26,9 +26,12 @@ export default createAppConnector<Finance, Config>(
         config?.pollInterval ?? orgConnector.config?.pollInterval ?? undefined
     }
 
-    return new Finance(
-      new FinanceConnectorTheGraph({ pollInterval, subgraphUrl, verbose }),
-      app.address
-    )
+    const connectorTheGraph = new FinanceConnectorTheGraph({
+      pollInterval,
+      subgraphUrl,
+      verbose,
+    })
+
+    return new Finance(connectorTheGraph, app.address)
   }
 )

--- a/packages/connect-finance/src/connect.ts
+++ b/packages/connect-finance/src/connect.ts
@@ -1,27 +1,33 @@
-import { createAppConnector, Network } from '@aragon/connect-core'
-import { IFinanceConnector } from './types'
+import { createAppConnector } from '@aragon/connect-core'
 import Finance from './models/Finance'
 import FinanceConnectorTheGraph, {
   subgraphUrlFromChainId,
 } from './thegraph/connector'
 
 type Config = {
-  subgraphUrl: string
+  pollInterval?: number
+  subgraphUrl?: string
 }
 
 export default createAppConnector<Finance, Config>(
-  async ({ app, config, connector, network, verbose }) => {
+  ({ app, config, connector, network, orgConnector, verbose }) => {
     if (connector !== 'thegraph') {
       console.warn(
         `Connector unsupported: ${connector}. Using "thegraph" instead.`
       )
     }
 
+    const subgraphUrl =
+      config.subgraphUrl ?? subgraphUrlFromChainId(network.chainId) ?? undefined
+
+    let pollInterval
+    if (orgConnector.name === 'thegraph') {
+      pollInterval =
+        config?.pollInterval ?? orgConnector.config?.pollInterval ?? undefined
+    }
+
     return new Finance(
-      new FinanceConnectorTheGraph(
-        config.subgraphUrl ?? subgraphUrlFromChainId(network.chainId),
-        verbose
-      ),
+      new FinanceConnectorTheGraph({ pollInterval, subgraphUrl, verbose }),
       app.address
     )
   }

--- a/packages/connect-finance/src/thegraph/connector.ts
+++ b/packages/connect-finance/src/thegraph/connector.ts
@@ -19,16 +19,25 @@ export function subgraphUrlFromChainId(chainId: number) {
   return null
 }
 
+type FinanceConnectorTheGraphConfig = {
+  pollInterval?: number
+  subgraphUrl?: string
+  verbose?: boolean
+}
+
 export default class FinanceConnectorTheGraph implements IFinanceConnector {
   #gql: GraphQLWrapper
 
-  constructor(subgraphUrl: string, verbose = false) {
-    if (!subgraphUrl) {
+  constructor(config: FinanceConnectorTheGraphConfig) {
+    if (!config.subgraphUrl) {
       throw new Error(
         'FinanceConnectorTheGraph requires subgraphUrl to be passed.'
       )
     }
-    this.#gql = new GraphQLWrapper(subgraphUrl, verbose)
+    this.#gql = new GraphQLWrapper(config.subgraphUrl, {
+      pollInterval: config.pollInterval,
+      verbose: config.verbose,
+    })
   }
 
   async disconnect() {

--- a/packages/connect-finance/src/thegraph/queries/index.ts
+++ b/packages/connect-finance/src/thegraph/queries/index.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 export const ALL_TRANSACTIONS = (type: string) => gql`
-  query Transactions($appAddress: String!, $first: Int!, $skip: Int!) {
+  ${type} Transactions($appAddress: String!, $first: Int!, $skip: Int!) {
     transactions(where: {
       appAddress: $appAddress
     }, first: $first, skip: $skip) {
@@ -19,7 +19,7 @@ export const ALL_TRANSACTIONS = (type: string) => gql`
 `
 
 export const BALANCE_FOR_TOKEN = (type: string) => gql`
-  query TokenBalances($appAddress: String!, $tokenAddress: String!, $first: Int!, $skip: Int!) {
+  ${type} TokenBalances($appAddress: String!, $tokenAddress: String!, $first: Int!, $skip: Int!) {
     tokenBalances(where: {
       token: $tokenAddress,
       appAddress: $appAddress

--- a/packages/connect-finance/src/thegraph/queries/index.ts
+++ b/packages/connect-finance/src/thegraph/queries/index.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 export const ALL_TRANSACTIONS = (type: string) => gql`
-  ${type} Transactions($appAddress: String!, $first: Int!, $skip: Int!) {
+  query Transactions($appAddress: String!, $first: Int!, $skip: Int!) {
     transactions(where: {
       appAddress: $appAddress
     }, first: $first, skip: $skip) {
@@ -19,7 +19,7 @@ export const ALL_TRANSACTIONS = (type: string) => gql`
 `
 
 export const BALANCE_FOR_TOKEN = (type: string) => gql`
-  ${type} TokenBalances($appAddress: String!, $tokenAddress: String!, $first: Int!, $skip: Int!) {
+  query TokenBalances($appAddress: String!, $tokenAddress: String!, $first: Int!, $skip: Int!) {
     tokenBalances(where: {
       token: $tokenAddress,
       appAddress: $appAddress

--- a/packages/connect-thegraph/src/connector.ts
+++ b/packages/connect-thegraph/src/connector.ts
@@ -28,6 +28,7 @@ import {
 export type ConnectorTheGraphConfig = {
   network: Networkish
   orgSubgraphUrl?: string
+  pollInterval?: number
   verbose?: boolean
 }
 
@@ -62,11 +63,13 @@ function appFiltersToQueryFilter(appFilters: AppFilters) {
 
 class ConnectorTheGraph implements IOrganizationConnector {
   #gql: GraphQLWrapper
+  connection?: ConnectionContext
+  readonly config: ConnectorTheGraphConfig
   readonly name = 'thegraph'
   readonly network: Network
-  connection?: ConnectionContext
 
   constructor(config: ConnectorTheGraphConfig) {
+    this.config = config
     this.network = toNetwork(config.network)
 
     const orgSubgraphUrl =
@@ -78,7 +81,10 @@ class ConnectorTheGraph implements IOrganizationConnector {
       )
     }
 
-    this.#gql = new GraphQLWrapper(orgSubgraphUrl, config.verbose)
+    this.#gql = new GraphQLWrapper(orgSubgraphUrl, {
+      pollInterval: config.pollInterval,
+      verbose: config.verbose,
+    })
   }
 
   async connect(connection: ConnectionContext) {

--- a/packages/connect-thegraph/src/core/GraphQLWrapper.ts
+++ b/packages/connect-thegraph/src/core/GraphQLWrapper.ts
@@ -47,6 +47,7 @@ export default class GraphQLWrapper {
       )
       options = { verbose: options }
     }
+    options = options as GraphQLWrapperOptions
 
     this.#verbose = options.verbose ?? false
     this.#pollInterval = options.pollInterval ?? POLL_INTERVAL_DEFAULT

--- a/packages/connect-thegraph/src/core/GraphQLWrapper.ts
+++ b/packages/connect-thegraph/src/core/GraphQLWrapper.ts
@@ -5,7 +5,9 @@ import { pipe, subscribe } from 'wonka'
 import { SubscriptionHandler } from '@aragon/connect-types'
 import { ParseFunction, QueryResult } from '../types'
 
-const POLL_INTERVAL = 5 * 1000
+// Average block time is about 13 seconds on the 2020-08-14
+// See https://etherscan.io/chart/blocktime
+const POLL_INTERVAL = 13 * 1000
 
 export default class GraphQLWrapper {
   #client: Client

--- a/packages/connect-thegraph/src/core/GraphQLWrapper.ts
+++ b/packages/connect-thegraph/src/core/GraphQLWrapper.ts
@@ -28,8 +28,8 @@ function createRequest(query: DocumentNode, args: object): GraphQLRequest {
 }
 
 type GraphQLWrapperOptions = {
-  verbose?: boolean
   pollInterval?: number
+  verbose?: boolean
 }
 
 export default class GraphQLWrapper {

--- a/packages/connect-thegraph/src/core/GraphQLWrapper.ts
+++ b/packages/connect-thegraph/src/core/GraphQLWrapper.ts
@@ -36,6 +36,7 @@ export default class GraphQLWrapper {
     return pipe(
       this.#client.executeQuery(request, {
         pollInterval: POLL_INTERVAL,
+        requestPolicy: 'cache-and-network',
       }),
       subscribe((result: QueryResult) => {
         if (this.#verbose) {

--- a/packages/connect-thegraph/src/core/GraphQLWrapper.ts
+++ b/packages/connect-thegraph/src/core/GraphQLWrapper.ts
@@ -5,8 +5,6 @@ import { pipe, subscribe } from 'wonka'
 import { SubscriptionHandler } from '@aragon/connect-types'
 import { ParseFunction, QueryResult } from '../types'
 
-// const AUTO_RECONNECT = true
-// const CONNECTION_TIMEOUT = 20 * 1000
 const POLL_INTERVAL = 5 * 1000
 
 export default class GraphQLWrapper {

--- a/packages/connect-thegraph/src/queries/index.ts
+++ b/packages/connect-thegraph/src/queries/index.ts
@@ -4,7 +4,7 @@ import * as fragments from './fragments'
 type Query = 'query' | 'subscription'
 
 export const ORGANIZATION_APPS = (type: Query) => gql`
-  query Organization($orgAddress: String!, $appFilter: App_filter!, $first: Int) {
+  ${type} Organization($orgAddress: String!, $appFilter: App_filter!, $first: Int) {
     organization(id: $orgAddress) {
       apps(where: $appFilter, first: $first) {
         ...App_app
@@ -15,7 +15,7 @@ export const ORGANIZATION_APPS = (type: Query) => gql`
 `
 
 export const APP_BY_ADDRESS = (type: Query) => gql`
-  query App($appAddress: String!) {
+  ${type} App($appAddress: String!) {
     app(id: $appAddress) {
       ...App_app
     }
@@ -24,7 +24,7 @@ export const APP_BY_ADDRESS = (type: Query) => gql`
 `
 
 export const REPO_BY_APP_ADDRESS = (type: Query) => gql`
-  query App($appAddress: String!) {
+  ${type} App($appAddress: String!) {
     app(id: $appAddress) {
       repo {
         ...Repo_repo
@@ -39,7 +39,7 @@ export const REPO_BY_APP_ADDRESS = (type: Query) => gql`
 `
 
 export const ORGANIZATION_PERMISSIONS = (type: Query) => gql`
-  query Organization($orgAddress: String!) {
+  ${type} Organization($orgAddress: String!) {
     organization(id: $orgAddress) {
       permissions {
         ...Permission_permission
@@ -50,7 +50,7 @@ export const ORGANIZATION_PERMISSIONS = (type: Query) => gql`
 `
 
 export const ROLE_BY_APP_ADDRESS = (type: Query) => gql`
-  query App($appAddress: String!) {
+  ${type} App($appAddress: String!) {
     app(id: $appAddress) {
       appId
       version{

--- a/packages/connect-thegraph/src/queries/index.ts
+++ b/packages/connect-thegraph/src/queries/index.ts
@@ -4,7 +4,7 @@ import * as fragments from './fragments'
 type Query = 'query' | 'subscription'
 
 export const ORGANIZATION_APPS = (type: Query) => gql`
-  ${type} Organization($orgAddress: String!, $appFilter: App_filter!, $first: Int) {
+  query Organization($orgAddress: String!, $appFilter: App_filter!, $first: Int) {
     organization(id: $orgAddress) {
       apps(where: $appFilter, first: $first) {
         ...App_app
@@ -15,7 +15,7 @@ export const ORGANIZATION_APPS = (type: Query) => gql`
 `
 
 export const APP_BY_ADDRESS = (type: Query) => gql`
-  ${type} App($appAddress: String!) {
+  query App($appAddress: String!) {
     app(id: $appAddress) {
       ...App_app
     }
@@ -24,7 +24,7 @@ export const APP_BY_ADDRESS = (type: Query) => gql`
 `
 
 export const REPO_BY_APP_ADDRESS = (type: Query) => gql`
-  ${type} App($appAddress: String!) {
+  query App($appAddress: String!) {
     app(id: $appAddress) {
       repo {
         ...Repo_repo
@@ -39,7 +39,7 @@ export const REPO_BY_APP_ADDRESS = (type: Query) => gql`
 `
 
 export const ORGANIZATION_PERMISSIONS = (type: Query) => gql`
-  ${type} Organization($orgAddress: String!) {
+  query Organization($orgAddress: String!) {
     organization(id: $orgAddress) {
       permissions {
         ...Permission_permission
@@ -50,7 +50,7 @@ export const ORGANIZATION_PERMISSIONS = (type: Query) => gql`
 `
 
 export const ROLE_BY_APP_ADDRESS = (type: Query) => gql`
-  ${type} App($appAddress: String!) {
+  query App($appAddress: String!) {
     app(id: $appAddress) {
       appId
       version{

--- a/packages/connect-tokens/src/connect.ts
+++ b/packages/connect-tokens/src/connect.ts
@@ -1,27 +1,37 @@
-import { createAppConnector, Network } from '@aragon/connect-core'
-import { ITokensConnector } from './types'
+import { createAppConnector } from '@aragon/connect-core'
 import Tokens from './models/Tokens'
 import TokensConnectorTheGraph, {
   subgraphUrlFromChainId,
 } from './thegraph/connector'
 
 type Config = {
+  pollInterval?: number
   subgraphUrl?: string
 }
 
 export default createAppConnector<Tokens, Config>(
-  async ({ app, config, connector, network, verbose }) => {
+  async ({ app, config, connector, network, orgConnector, verbose }) => {
     if (connector !== 'thegraph') {
       console.warn(
         `Connector unsupported: ${connector}. Using "thegraph" instead.`
       )
     }
 
-    const tokensConnector = await TokensConnectorTheGraph.create(
-      config.subgraphUrl ?? (subgraphUrlFromChainId(network.chainId) || ''),
-      app.address,
-      verbose
-    )
+    const subgraphUrl =
+      config.subgraphUrl ?? subgraphUrlFromChainId(network.chainId) ?? undefined
+
+    let pollInterval
+    if (orgConnector.name === 'thegraph') {
+      pollInterval =
+        config?.pollInterval ?? orgConnector.config?.pollInterval ?? undefined
+    }
+
+    const tokensConnector = await TokensConnectorTheGraph.create({
+      appAddress: app.address,
+      pollInterval,
+      subgraphUrl,
+      verbose,
+    })
 
     return new Tokens(tokensConnector, app.address)
   }

--- a/packages/connect-tokens/src/connect.ts
+++ b/packages/connect-tokens/src/connect.ts
@@ -26,13 +26,13 @@ export default createAppConnector<Tokens, Config>(
         config?.pollInterval ?? orgConnector.config?.pollInterval ?? undefined
     }
 
-    const tokensConnector = await TokensConnectorTheGraph.create({
+    const connectorTheGraph = await TokensConnectorTheGraph.create({
       appAddress: app.address,
       pollInterval,
       subgraphUrl,
       verbose,
     })
 
-    return new Tokens(tokensConnector, app.address)
+    return new Tokens(connectorTheGraph, app.address)
   }
 )

--- a/packages/connect-tokens/src/thegraph/connector.ts
+++ b/packages/connect-tokens/src/thegraph/connector.ts
@@ -19,6 +19,13 @@ export function subgraphUrlFromChainId(chainId: number) {
   return null
 }
 
+type TokensConnectorTheGraphConfig = {
+  appAddress?: Address
+  pollInterval?: number
+  subgraphUrl?: string
+  verbose?: boolean
+}
+
 export default class TokensConnectorTheGraph implements ITokensConnector {
   #gql: GraphQLWrapper
   #token: Token
@@ -29,21 +36,28 @@ export default class TokensConnectorTheGraph implements ITokensConnector {
   }
 
   static async create(
-    subgraphUrl: string,
-    appAddress: Address,
-    verbose: boolean = false
+    config: TokensConnectorTheGraphConfig
   ): Promise<TokensConnectorTheGraph> {
-    if (!subgraphUrl) {
+    if (!config.subgraphUrl) {
       throw new Error(
         'TokensConnectorTheGraph requires subgraphUrl to be passed.'
       )
     }
 
-    const gql = new GraphQLWrapper(subgraphUrl, verbose)
+    if (!config.appAddress) {
+      throw new Error(
+        'TokensConnectorTheGraph requires appAddress to be passed.'
+      )
+    }
+
+    const gql = new GraphQLWrapper(config.subgraphUrl, {
+      pollInterval: config.pollInterval,
+      verbose: config.verbose,
+    })
 
     const token = await gql.performQueryWithParser<Token>(
       queries.TOKEN('query'),
-      { tokenManagerAddress: appAddress },
+      { tokenManagerAddress: config.appAddress },
       (result) => parseToken(result)
     )
 

--- a/packages/connect-tokens/src/thegraph/queries/index.ts
+++ b/packages/connect-tokens/src/thegraph/queries/index.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 export const TOKEN = (type: string) => gql`
-  query MiniMeToken($tokenManagerAddress: String!) {
+  ${type} MiniMeToken($tokenManagerAddress: String!) {
     miniMeTokens(where: {
       appAddress: $tokenManagerAddress
     }) {
@@ -18,7 +18,7 @@ export const TOKEN = (type: string) => gql`
 `
 
 export const TOKEN_HOLDERS = (type: string) => gql`
-  query TokenHolders($tokenAddress: String!, $first: Int!, $skip: Int!) {
+  ${type} TokenHolders($tokenAddress: String!, $first: Int!, $skip: Int!) {
     tokenHolders(where: {
       tokenAddress: $tokenAddress
     }, first: $first, skip: $skip) {

--- a/packages/connect-tokens/src/thegraph/queries/index.ts
+++ b/packages/connect-tokens/src/thegraph/queries/index.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 export const TOKEN = (type: string) => gql`
-  ${type} MiniMeToken($tokenManagerAddress: String!) {
+  query MiniMeToken($tokenManagerAddress: String!) {
     miniMeTokens(where: {
       appAddress: $tokenManagerAddress
     }) {
@@ -18,7 +18,7 @@ export const TOKEN = (type: string) => gql`
 `
 
 export const TOKEN_HOLDERS = (type: string) => gql`
-  ${type} TokenHolders($tokenAddress: String!, $first: Int!, $skip: Int!) {
+  query TokenHolders($tokenAddress: String!, $first: Int!, $skip: Int!) {
     tokenHolders(where: {
       tokenAddress: $tokenAddress
     }, first: $first, skip: $skip) {

--- a/packages/connect-voting-disputable/src/__test__/models/votes.test.ts
+++ b/packages/connect-voting-disputable/src/__test__/models/votes.test.ts
@@ -1,13 +1,21 @@
-import { DisputableVoting, Vote, CastVote, DisputableVotingConnectorTheGraph } from '../../../src'
+import {
+  DisputableVoting,
+  Vote,
+  CastVote,
+  DisputableVotingConnectorTheGraph,
+} from '../../../src'
 
 const VOTING_APP_ADDRESS = '0x26e14ed789b51b5b226d69a5d40f72dc2d0180fe'
-const VOTING_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/facuspagnuolo/aragon-dvoting-rinkeby-staging'
+const VOTING_SUBGRAPH_URL =
+  'https://api.thegraph.com/subgraphs/name/facuspagnuolo/aragon-dvoting-rinkeby-staging'
 
 describe('DisputableVoting', () => {
   let voting: DisputableVoting
 
   beforeAll(() => {
-    const connector = new DisputableVotingConnectorTheGraph(VOTING_SUBGRAPH_URL)
+    const connector = new DisputableVotingConnectorTheGraph({
+      subgraphUrl: VOTING_SUBGRAPH_URL,
+    })
     voting = new DisputableVoting(connector, VOTING_APP_ADDRESS)
   })
 
@@ -18,11 +26,17 @@ describe('DisputableVoting', () => {
   describe('end date', () => {
     test('computes the end date properly', async () => {
       const scheduledVote = await voting.vote(`${VOTING_APP_ADDRESS}-vote-0`)
-      const expectedScheduledVoteEndDate = parseInt(scheduledVote.startDate) + parseInt(scheduledVote.duration)
-      expect(scheduledVote.endDate).toBe(expectedScheduledVoteEndDate.toString())
+      const expectedScheduledVoteEndDate =
+        parseInt(scheduledVote.startDate) + parseInt(scheduledVote.duration)
+      expect(scheduledVote.endDate).toBe(
+        expectedScheduledVoteEndDate.toString()
+      )
 
       const settledVote = await voting.vote(`${VOTING_APP_ADDRESS}-vote-2`)
-      const expectedSettledVoteEndDate = parseInt(settledVote.startDate) + parseInt(settledVote.duration) + parseInt(settledVote.pauseDuration)
+      const expectedSettledVoteEndDate =
+        parseInt(settledVote.startDate) +
+        parseInt(settledVote.duration) +
+        parseInt(settledVote.pauseDuration)
       expect(settledVote.endDate).toBe(expectedSettledVoteEndDate.toString())
     })
   })
@@ -67,8 +81,8 @@ describe('DisputableVoting', () => {
       test('fetches the cast vote info', async () => {
         expect(castVote.id).toBe(`${VOTE_ID}-cast-${VOTER_ADDRESS}`)
         expect(castVote.supports).toBe(false)
-        expect(castVote.stake).toBe("1000000000000000000")
-        expect(castVote.createdAt).toBe("1596394229")
+        expect(castVote.stake).toBe('1000000000000000000')
+        expect(castVote.createdAt).toBe('1596394229')
         expect(castVote.caster).toBe(VOTER_ADDRESS)
       })
 
@@ -87,7 +101,9 @@ describe('DisputableVoting', () => {
       const collateralRequirement = await vote.collateralRequirement()
 
       expect(collateralRequirement.id).toBe(voteId)
-      expect(collateralRequirement.token).toBe('0x3af6b2f907f0c55f279e0ed65751984e6cdc4a42')
+      expect(collateralRequirement.token).toBe(
+        '0x3af6b2f907f0c55f279e0ed65751984e6cdc4a42'
+      )
       expect(collateralRequirement.actionAmount).toBe('0')
       expect(collateralRequirement.challengeAmount).toBe('0')
       expect(collateralRequirement.challengeDuration).toBe('259200')

--- a/packages/connect-voting-disputable/src/__test__/thegraph/disputableVoting.test.ts
+++ b/packages/connect-voting-disputable/src/__test__/thegraph/disputableVoting.test.ts
@@ -2,13 +2,16 @@ import { DisputableVotingData } from '../../types'
 import { DisputableVotingConnectorTheGraph } from '../../../src'
 
 const VOTING_APP_ADDRESS = '0x26e14ed789b51b5b226d69a5d40f72dc2d0180fe'
-const VOTING_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/facuspagnuolo/aragon-dvoting-rinkeby-staging'
+const VOTING_SUBGRAPH_URL =
+  'https://api.thegraph.com/subgraphs/name/facuspagnuolo/aragon-dvoting-rinkeby-staging'
 
 describe('DisputableVoting', () => {
   let connector: DisputableVotingConnectorTheGraph
 
   beforeAll(() => {
-    connector = new DisputableVotingConnectorTheGraph(VOTING_SUBGRAPH_URL)
+    connector = new DisputableVotingConnectorTheGraph({
+      subgraphUrl: VOTING_SUBGRAPH_URL,
+    })
   })
 
   afterAll(async () => {
@@ -24,8 +27,12 @@ describe('DisputableVoting', () => {
 
     test('returns the disputable voting data', () => {
       expect(disputableVoting.id).toBe(VOTING_APP_ADDRESS)
-      expect(disputableVoting.dao).toBe('0xa6e4b08981ae324f16d6be39362f6de2da22882a')
-      expect(disputableVoting.token).toBe('0x991f49aad101db17ff02d8d867a880703bface62')
+      expect(disputableVoting.dao).toBe(
+        '0xa6e4b08981ae324f16d6be39362f6de2da22882a'
+      )
+      expect(disputableVoting.token).toBe(
+        '0x991f49aad101db17ff02d8d867a880703bface62'
+      )
     })
   })
 })

--- a/packages/connect-voting-disputable/src/__test__/thegraph/settings.test.ts
+++ b/packages/connect-voting-disputable/src/__test__/thegraph/settings.test.ts
@@ -1,13 +1,16 @@
 import { DisputableVotingConnectorTheGraph, Setting } from '../../../src'
 
 const VOTING_APP_ADDRESS = '0x26e14ed789b51b5b226d69a5d40f72dc2d0180fe'
-const VOTING_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/facuspagnuolo/aragon-dvoting-rinkeby-staging'
+const VOTING_SUBGRAPH_URL =
+  'https://api.thegraph.com/subgraphs/name/facuspagnuolo/aragon-dvoting-rinkeby-staging'
 
 describe('DisputableVoting settings', () => {
   let connector: DisputableVotingConnectorTheGraph
 
   beforeAll(() => {
-    connector = new DisputableVotingConnectorTheGraph(VOTING_SUBGRAPH_URL)
+    connector = new DisputableVotingConnectorTheGraph({
+      subgraphUrl: VOTING_SUBGRAPH_URL,
+    })
   })
 
   afterAll(async () => {

--- a/packages/connect-voting-disputable/src/__test__/thegraph/voters.test.ts
+++ b/packages/connect-voting-disputable/src/__test__/thegraph/voters.test.ts
@@ -2,13 +2,16 @@ import { DisputableVotingConnectorTheGraph, Voter } from '../../../src'
 
 const VOTER_ADDRESS = '0x0090aed150056316e37fe6dfa10dc63e79d173b6'
 const VOTING_APP_ADDRESS = '0x26e14ed789b51b5b226d69a5d40f72dc2d0180fe'
-const VOTING_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/facuspagnuolo/aragon-dvoting-rinkeby-staging'
+const VOTING_SUBGRAPH_URL =
+  'https://api.thegraph.com/subgraphs/name/facuspagnuolo/aragon-dvoting-rinkeby-staging'
 
 describe('DisputableVoting voters', () => {
   let connector: DisputableVotingConnectorTheGraph
 
   beforeAll(() => {
-    connector = new DisputableVotingConnectorTheGraph(VOTING_SUBGRAPH_URL)
+    connector = new DisputableVotingConnectorTheGraph({
+      subgraphUrl: VOTING_SUBGRAPH_URL,
+    })
   })
 
   afterAll(async () => {
@@ -19,7 +22,9 @@ describe('DisputableVoting voters', () => {
     let voter: Voter
 
     beforeAll(async () => {
-      voter = await connector.voter(`${VOTING_APP_ADDRESS}-voter-${VOTER_ADDRESS}`)
+      voter = await connector.voter(
+        `${VOTING_APP_ADDRESS}-voter-${VOTER_ADDRESS}`
+      )
     })
 
     test('allows fetching voter information', async () => {

--- a/packages/connect-voting-disputable/src/__test__/thegraph/votes.test.ts
+++ b/packages/connect-voting-disputable/src/__test__/thegraph/votes.test.ts
@@ -1,13 +1,16 @@
 import { DisputableVotingConnectorTheGraph, Vote, CastVote } from '../../../src'
 
 const VOTING_APP_ADDRESS = '0x26e14ed789b51b5b226d69a5d40f72dc2d0180fe'
-const VOTING_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/facuspagnuolo/aragon-dvoting-rinkeby-staging'
+const VOTING_SUBGRAPH_URL =
+  'https://api.thegraph.com/subgraphs/name/facuspagnuolo/aragon-dvoting-rinkeby-staging'
 
 describe('DisputableVoting votes', () => {
   let connector: DisputableVotingConnectorTheGraph
 
   beforeAll(() => {
-    connector = new DisputableVotingConnectorTheGraph(VOTING_SUBGRAPH_URL)
+    connector = new DisputableVotingConnectorTheGraph({
+      subgraphUrl: VOTING_SUBGRAPH_URL,
+    })
   })
 
   afterAll(async () => {
@@ -47,15 +50,23 @@ describe('DisputableVoting votes', () => {
       expect(castVotes.length).toBeGreaterThan(1)
 
       const firstCastVote = castVotes[0]
-      expect(firstCastVote.id).toBe(`${VOTING_APP_ADDRESS}-vote-4-cast-0x0090aed150056316e37fe6dfa10dc63e79d173b6`)
-      expect(firstCastVote.caster).toBe('0x0090aed150056316e37fe6dfa10dc63e79d173b6')
+      expect(firstCastVote.id).toBe(
+        `${VOTING_APP_ADDRESS}-vote-4-cast-0x0090aed150056316e37fe6dfa10dc63e79d173b6`
+      )
+      expect(firstCastVote.caster).toBe(
+        '0x0090aed150056316e37fe6dfa10dc63e79d173b6'
+      )
       expect(firstCastVote.createdAt).toEqual('1596383834')
       expect(firstCastVote.stake).toBe('1000000000000000000')
       expect(firstCastVote.supports).toBe(true)
 
       const secondCastVote = castVotes[1]
-      expect(secondCastVote.id).toBe(`${VOTING_APP_ADDRESS}-vote-4-cast-0xa9ac50dce74c46025dc9dceafb4fa21f0dc142ea`)
-      expect(secondCastVote.caster).toBe('0xa9ac50dce74c46025dc9dceafb4fa21f0dc142ea')
+      expect(secondCastVote.id).toBe(
+        `${VOTING_APP_ADDRESS}-vote-4-cast-0xa9ac50dce74c46025dc9dceafb4fa21f0dc142ea`
+      )
+      expect(secondCastVote.caster).toBe(
+        '0xa9ac50dce74c46025dc9dceafb4fa21f0dc142ea'
+      )
       expect(secondCastVote.createdAt).toEqual('1596394454')
       expect(secondCastVote.stake).toBe('1000000000000000000')
       expect(secondCastVote.supports).toBe(false)
@@ -97,4 +108,3 @@ describe('DisputableVoting votes', () => {
     })
   })
 })
-

--- a/packages/connect-voting-disputable/src/connect.ts
+++ b/packages/connect-voting-disputable/src/connect.ts
@@ -1,20 +1,38 @@
 import { createAppConnector } from '@aragon/connect-core'
-
 import DisputableVoting from './models/DisputableVoting'
-import DisputableVotingConnectorTheGraph, { subgraphUrlFromChainId } from './thegraph/connector'
+import DisputableVotingConnectorTheGraph, {
+  subgraphUrlFromChainId,
+} from './thegraph/connector'
 
 type Config = {
-  subgraphUrl: string
+  pollInterval?: number
+  subgraphUrl?: string
 }
 
 export default createAppConnector<DisputableVoting, Config>(
-  ({ app, config, connector, network, verbose }) => {
+  ({ app, config, connector, network, orgConnector, verbose }) => {
     if (connector !== 'thegraph') {
-      console.warn(`Connector unsupported: ${connector}. Using "thegraph" instead.`)
+      console.warn(
+        `Connector unsupported: ${connector}. Using "thegraph" instead.`
+      )
     }
 
-    const subgraphUrl = config.subgraphUrl ?? subgraphUrlFromChainId(network.chainId)
-    const votingConnector = new DisputableVotingConnectorTheGraph(subgraphUrl, verbose)
-    return new DisputableVoting(votingConnector, app.address)
+    const subgraphUrl =
+      config.subgraphUrl ?? subgraphUrlFromChainId(network.chainId) ?? undefined
+
+    let pollInterval
+    if (orgConnector.name === 'thegraph') {
+      pollInterval =
+        config?.pollInterval ?? orgConnector.config?.pollInterval ?? undefined
+    }
+
+    return new DisputableVoting(
+      new DisputableVotingConnectorTheGraph({
+        pollInterval,
+        subgraphUrl,
+        verbose,
+      }),
+      app.address
+    )
   }
 )

--- a/packages/connect-voting-disputable/src/connect.ts
+++ b/packages/connect-voting-disputable/src/connect.ts
@@ -26,13 +26,12 @@ export default createAppConnector<DisputableVoting, Config>(
         config?.pollInterval ?? orgConnector.config?.pollInterval ?? undefined
     }
 
-    return new DisputableVoting(
-      new DisputableVotingConnectorTheGraph({
-        pollInterval,
-        subgraphUrl,
-        verbose,
-      }),
-      app.address
-    )
+    const connectorTheGraph = new DisputableVotingConnectorTheGraph({
+      pollInterval,
+      subgraphUrl,
+      verbose,
+    })
+
+    return new DisputableVoting(connectorTheGraph, app.address)
   }
 )

--- a/packages/connect-voting-disputable/src/thegraph/connector.ts
+++ b/packages/connect-voting-disputable/src/thegraph/connector.ts
@@ -18,7 +18,7 @@ import {
   parseVotes,
   parseCastVote,
   parseCastVotes,
-  parseCollateralRequirement
+  parseCollateralRequirement,
 } from './parsers'
 
 export function subgraphUrlFromChainId(chainId: number) {
@@ -34,21 +34,35 @@ export function subgraphUrlFromChainId(chainId: number) {
   return null
 }
 
-export default class DisputableVotingConnectorTheGraph implements IDisputableVotingConnector {
+type DisputableVotingConnectorTheGraphConfig = {
+  pollInterval?: number
+  subgraphUrl?: string
+  verbose?: boolean
+}
+
+export default class DisputableVotingConnectorTheGraph
+  implements IDisputableVotingConnector {
   #gql: GraphQLWrapper
 
-  constructor(subgraphUrl: string, verbose: boolean = false) {
-    if (!subgraphUrl) {
-      throw new Error('DisputableVotingConnectorTheGraph requires subgraphUrl to be passed.')
+  constructor(config: DisputableVotingConnectorTheGraphConfig) {
+    if (!config.subgraphUrl) {
+      throw new Error(
+        'DisputableVotingConnectorTheGraph requires subgraphUrl to be passed.'
+      )
     }
-    this.#gql = new GraphQLWrapper(subgraphUrl, verbose)
+    this.#gql = new GraphQLWrapper(config.subgraphUrl, {
+      pollInterval: config.pollInterval,
+      verbose: config.verbose,
+    })
   }
 
   async disconnect() {
     this.#gql.close()
   }
 
-  async disputableVoting(disputableVoting: string): Promise<DisputableVotingData> {
+  async disputableVoting(
+    disputableVoting: string
+  ): Promise<DisputableVotingData> {
     return this.#gql.performQueryWithParser(
       queries.GET_DISPUTABLE_VOTING('query'),
       { disputableVoting },
@@ -56,7 +70,10 @@ export default class DisputableVotingConnectorTheGraph implements IDisputableVot
     )
   }
 
-  onDisputableVoting(disputableVoting: string, callback: Function): SubscriptionHandler {
+  onDisputableVoting(
+    disputableVoting: string,
+    callback: Function
+  ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser(
       queries.GET_DISPUTABLE_VOTING('subscription'),
       { disputableVoting },
@@ -73,7 +90,10 @@ export default class DisputableVotingConnectorTheGraph implements IDisputableVot
     )
   }
 
-  onCurrentSetting(disputableVoting: string, callback: Function): SubscriptionHandler {
+  onCurrentSetting(
+    disputableVoting: string,
+    callback: Function
+  ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser(
       queries.GET_CURRENT_SETTING('subscription'),
       { disputableVoting },
@@ -99,7 +119,11 @@ export default class DisputableVotingConnectorTheGraph implements IDisputableVot
     )
   }
 
-  async settings(disputableVoting: string, first: number, skip: number): Promise<Setting[]> {
+  async settings(
+    disputableVoting: string,
+    first: number,
+    skip: number
+  ): Promise<Setting[]> {
     return this.#gql.performQueryWithParser(
       queries.ALL_SETTINGS('query'),
       { disputableVoting, first, skip },
@@ -107,7 +131,12 @@ export default class DisputableVotingConnectorTheGraph implements IDisputableVot
     )
   }
 
-  onSettings(disputableVoting: string, first: number, skip: number, callback: Function): SubscriptionHandler {
+  onSettings(
+    disputableVoting: string,
+    first: number,
+    skip: number,
+    callback: Function
+  ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser(
       queries.ALL_SETTINGS('subscription'),
       { disputableVoting, first, skip },
@@ -133,7 +162,11 @@ export default class DisputableVotingConnectorTheGraph implements IDisputableVot
     )
   }
 
-  async votes(disputableVoting: string, first: number, skip: number): Promise<Vote[]> {
+  async votes(
+    disputableVoting: string,
+    first: number,
+    skip: number
+  ): Promise<Vote[]> {
     return this.#gql.performQueryWithParser(
       queries.ALL_VOTES('query'),
       { disputableVoting, first, skip },
@@ -141,7 +174,12 @@ export default class DisputableVotingConnectorTheGraph implements IDisputableVot
     )
   }
 
-  onVotes(disputableVoting: string, first: number, skip: number, callback: Function): SubscriptionHandler {
+  onVotes(
+    disputableVoting: string,
+    first: number,
+    skip: number,
+    callback: Function
+  ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser(
       queries.ALL_VOTES('subscription'),
       { disputableVoting, first, skip },
@@ -167,7 +205,11 @@ export default class DisputableVotingConnectorTheGraph implements IDisputableVot
     )
   }
 
-  async castVotes(voteId: string, first: number, skip: number): Promise<CastVote[]> {
+  async castVotes(
+    voteId: string,
+    first: number,
+    skip: number
+  ): Promise<CastVote[]> {
     return this.#gql.performQueryWithParser(
       queries.ALL_CAST_VOTES('query'),
       { voteId, first, skip },
@@ -175,7 +217,12 @@ export default class DisputableVotingConnectorTheGraph implements IDisputableVot
     )
   }
 
-  onCastVotes(voteId: string, first: number, skip: number, callback: Function): SubscriptionHandler {
+  onCastVotes(
+    voteId: string,
+    first: number,
+    skip: number,
+    callback: Function
+  ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser(
       queries.ALL_CAST_VOTES('subscription'),
       { voteId, first, skip },
@@ -209,7 +256,10 @@ export default class DisputableVotingConnectorTheGraph implements IDisputableVot
     )
   }
 
-  onCollateralRequirement(voteId: string, callback: Function): SubscriptionHandler {
+  onCollateralRequirement(
+    voteId: string,
+    callback: Function
+  ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser(
       queries.GET_COLLATERAL_REQUIREMENT('subscription'),
       { voteId },

--- a/packages/connect-voting-disputable/src/thegraph/queries/index.ts
+++ b/packages/connect-voting-disputable/src/thegraph/queries/index.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 export const GET_DISPUTABLE_VOTING = (type: string) => gql`
-  query DisputableVoting($disputableVoting: String!) {
+  ${type} DisputableVoting($disputableVoting: String!) {
     disputableVoting(id: $disputableVoting) {
       id
       dao
@@ -16,7 +16,7 @@ export const GET_DISPUTABLE_VOTING = (type: string) => gql`
 `
 
 export const GET_CURRENT_SETTING = (type: string) => gql`
-  query DisputableVoting($disputableVoting: String!) {
+  ${type} DisputableVoting($disputableVoting: String!) {
     disputableVoting(id: $disputableVoting) {
       setting {
         id
@@ -37,7 +37,7 @@ export const GET_CURRENT_SETTING = (type: string) => gql`
 `
 
 export const GET_SETTING = (type: string) => gql`
-  query Setting($settingId: String!) {
+  ${type} Setting($settingId: String!) {
     setting(id: $settingId) {
       id
       settingId
@@ -56,7 +56,7 @@ export const GET_SETTING = (type: string) => gql`
 `
 
 export const ALL_SETTINGS = (type: string) => gql`
-  query Settings($disputableVoting: String!, $first: Int!, $skip: Int!) {
+  ${type} Settings($disputableVoting: String!, $first: Int!, $skip: Int!) {
     settings(where: {
       voting: $disputableVoting
     }, first: $first, skip: $skip) {
@@ -77,7 +77,7 @@ export const ALL_SETTINGS = (type: string) => gql`
 `
 
 export const GET_VOTE = (type: string) => gql`
-  query Vote($voteId: String!) {
+  ${type} Vote($voteId: String!) {
     vote(id: $voteId) {
       id
       voting { 
@@ -107,7 +107,7 @@ export const GET_VOTE = (type: string) => gql`
 `
 
 export const ALL_VOTES = (type: string) => gql`
-  query Votes($disputableVoting: String!, $first: Int!, $skip: Int!) {
+  ${type} Votes($disputableVoting: String!, $first: Int!, $skip: Int!) {
     votes(where: {
       voting: $disputableVoting
     }, first: $first, skip: $skip) {
@@ -139,7 +139,7 @@ export const ALL_VOTES = (type: string) => gql`
 `
 
 export const GET_CAST_VOTE = (type: string) => gql`
-  query CastVote($castVoteId: String!) {
+  ${type} CastVote($castVoteId: String!) {
     castVote(id: $castVoteId) {
       id
       vote { 
@@ -157,7 +157,7 @@ export const GET_CAST_VOTE = (type: string) => gql`
 `
 
 export const ALL_CAST_VOTES = (type: string) => gql`
-  query CastVotes($voteId: ID!, $first: Int!, $skip: Int!) {
+  ${type} CastVotes($voteId: ID!, $first: Int!, $skip: Int!) {
     castVotes(where: {
       vote: $voteId
     }, first: $first, skip: $skip) {
@@ -177,7 +177,7 @@ export const ALL_CAST_VOTES = (type: string) => gql`
 `
 
 export const GET_VOTER = (type: string) => gql`
-  query Voter($voterId: String!) {
+  ${type} Voter($voterId: String!) {
     voter(id: $voterId) {
       id
       address
@@ -190,7 +190,7 @@ export const GET_VOTER = (type: string) => gql`
 `
 
 export const GET_COLLATERAL_REQUIREMENT = (type: string) => gql`
-  query CollateralRequirement($voteId: String!) {
+  ${type} CollateralRequirement($voteId: String!) {
     vote(id: $voteId) {
       collateralRequirement {
         id

--- a/packages/connect-voting-disputable/src/thegraph/queries/index.ts
+++ b/packages/connect-voting-disputable/src/thegraph/queries/index.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 export const GET_DISPUTABLE_VOTING = (type: string) => gql`
-  ${type} DisputableVoting($disputableVoting: String!) {
+  query DisputableVoting($disputableVoting: String!) {
     disputableVoting(id: $disputableVoting) {
       id
       dao
@@ -16,7 +16,7 @@ export const GET_DISPUTABLE_VOTING = (type: string) => gql`
 `
 
 export const GET_CURRENT_SETTING = (type: string) => gql`
-  ${type} DisputableVoting($disputableVoting: String!) {
+  query DisputableVoting($disputableVoting: String!) {
     disputableVoting(id: $disputableVoting) {
       setting {
         id
@@ -37,7 +37,7 @@ export const GET_CURRENT_SETTING = (type: string) => gql`
 `
 
 export const GET_SETTING = (type: string) => gql`
-  ${type} Setting($settingId: String!) {
+  query Setting($settingId: String!) {
     setting(id: $settingId) {
       id
       settingId
@@ -56,7 +56,7 @@ export const GET_SETTING = (type: string) => gql`
 `
 
 export const ALL_SETTINGS = (type: string) => gql`
-  ${type} Settings($disputableVoting: String!, $first: Int!, $skip: Int!) {
+  query Settings($disputableVoting: String!, $first: Int!, $skip: Int!) {
     settings(where: {
       voting: $disputableVoting
     }, first: $first, skip: $skip) {
@@ -77,7 +77,7 @@ export const ALL_SETTINGS = (type: string) => gql`
 `
 
 export const GET_VOTE = (type: string) => gql`
-  ${type} Vote($voteId: String!) {
+  query Vote($voteId: String!) {
     vote(id: $voteId) {
       id
       voting { 
@@ -107,7 +107,7 @@ export const GET_VOTE = (type: string) => gql`
 `
 
 export const ALL_VOTES = (type: string) => gql`
-  ${type} Votes($disputableVoting: String!, $first: Int!, $skip: Int!) {
+  query Votes($disputableVoting: String!, $first: Int!, $skip: Int!) {
     votes(where: {
       voting: $disputableVoting
     }, first: $first, skip: $skip) {
@@ -139,7 +139,7 @@ export const ALL_VOTES = (type: string) => gql`
 `
 
 export const GET_CAST_VOTE = (type: string) => gql`
-  ${type} CastVote($castVoteId: String!) {
+  query CastVote($castVoteId: String!) {
     castVote(id: $castVoteId) {
       id
       vote { 
@@ -157,7 +157,7 @@ export const GET_CAST_VOTE = (type: string) => gql`
 `
 
 export const ALL_CAST_VOTES = (type: string) => gql`
-  ${type} CastVotes($voteId: ID!, $first: Int!, $skip: Int!) {
+  query CastVotes($voteId: ID!, $first: Int!, $skip: Int!) {
     castVotes(where: {
       vote: $voteId
     }, first: $first, skip: $skip) {
@@ -177,7 +177,7 @@ export const ALL_CAST_VOTES = (type: string) => gql`
 `
 
 export const GET_VOTER = (type: string) => gql`
-  ${type} Voter($voterId: String!) {
+  query Voter($voterId: String!) {
     voter(id: $voterId) {
       id
       address
@@ -190,7 +190,7 @@ export const GET_VOTER = (type: string) => gql`
 `
 
 export const GET_COLLATERAL_REQUIREMENT = (type: string) => gql`
-  ${type} CollateralRequirement($voteId: String!) {
+  query CollateralRequirement($voteId: String!) {
     vote(id: $voteId) {
       collateralRequirement {
         id

--- a/packages/connect-voting/src/__test__/casts.test.ts
+++ b/packages/connect-voting/src/__test__/casts.test.ts
@@ -8,7 +8,9 @@ describe('when connecting to a voting app', () => {
   let connector: VotingConnectorTheGraph
 
   beforeAll(() => {
-    connector = new VotingConnectorTheGraph(VOTING_SUBGRAPH_URL)
+    connector = new VotingConnectorTheGraph({
+      subgraphUrl: VOTING_SUBGRAPH_URL,
+    })
   })
 
   afterAll(async () => {

--- a/packages/connect-voting/src/__test__/votes.test.ts
+++ b/packages/connect-voting/src/__test__/votes.test.ts
@@ -8,7 +8,9 @@ describe('when connecting to a voting app', () => {
   let connector: VotingConnectorTheGraph
 
   beforeAll(() => {
-    connector = new VotingConnectorTheGraph(VOTING_SUBGRAPH_URL)
+    connector = new VotingConnectorTheGraph({
+      subgraphUrl: VOTING_SUBGRAPH_URL,
+    })
   })
 
   afterAll(async () => {

--- a/packages/connect-voting/src/connect.ts
+++ b/packages/connect-voting/src/connect.ts
@@ -26,9 +26,12 @@ export default createAppConnector<Voting, Config>(
         config?.pollInterval ?? orgConnector.config?.pollInterval ?? undefined
     }
 
-    return new Voting(
-      new VotingConnectorTheGraph({ pollInterval, subgraphUrl, verbose }),
-      app.address
-    )
+    const connectorTheGraph = new VotingConnectorTheGraph({
+      pollInterval,
+      subgraphUrl,
+      verbose,
+    })
+
+    return new Voting(connectorTheGraph, app.address)
   }
 )

--- a/packages/connect-voting/src/connect.ts
+++ b/packages/connect-voting/src/connect.ts
@@ -5,22 +5,29 @@ import VotingConnectorTheGraph, {
 } from './thegraph/connector'
 
 type Config = {
-  subgraphUrl: string
+  pollInterval?: number
+  subgraphUrl?: string
 }
 
 export default createAppConnector<Voting, Config>(
-  ({ app, config, connector, network, verbose }) => {
+  ({ app, config, connector, network, orgConnector, verbose }) => {
     if (connector !== 'thegraph') {
       console.warn(
         `Connector unsupported: ${connector}. Using "thegraph" instead.`
       )
     }
 
+    const subgraphUrl =
+      config.subgraphUrl ?? subgraphUrlFromChainId(network.chainId) ?? undefined
+
+    let pollInterval
+    if (orgConnector.name === 'thegraph') {
+      pollInterval =
+        config?.pollInterval ?? orgConnector.config?.pollInterval ?? undefined
+    }
+
     return new Voting(
-      new VotingConnectorTheGraph(
-        config.subgraphUrl ?? subgraphUrlFromChainId(network.chainId),
-        verbose
-      ),
+      new VotingConnectorTheGraph({ pollInterval, subgraphUrl, verbose }),
       app.address
     )
   }

--- a/packages/connect-voting/src/thegraph/connector.ts
+++ b/packages/connect-voting/src/thegraph/connector.ts
@@ -19,16 +19,25 @@ export function subgraphUrlFromChainId(chainId: number) {
   return null
 }
 
+type VotingConnectorTheGraphConfig = {
+  pollInterval?: number
+  subgraphUrl?: string
+  verbose?: boolean
+}
+
 export default class VotingConnectorTheGraph implements IVotingConnector {
   #gql: GraphQLWrapper
 
-  constructor(subgraphUrl: string, verbose: boolean = false) {
-    if (!subgraphUrl) {
+  constructor(config: VotingConnectorTheGraphConfig) {
+    if (!config.subgraphUrl) {
       throw new Error(
         'VotingConnectorTheGraph requires subgraphUrl to be passed.'
       )
     }
-    this.#gql = new GraphQLWrapper(subgraphUrl, verbose)
+    this.#gql = new GraphQLWrapper(config.subgraphUrl, {
+      pollInterval: config.pollInterval,
+      verbose: config.verbose,
+    })
   }
 
   async disconnect() {

--- a/packages/connect-voting/src/thegraph/queries/index.ts
+++ b/packages/connect-voting/src/thegraph/queries/index.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 export const ALL_VOTES = (type: string) => gql`
-  query Votes($appAddress: String!, $first: Int!, $skip: Int!) {
+  ${type} Votes($appAddress: String!, $first: Int!, $skip: Int!) {
     votes(where: {
       appAddress: $appAddress
     }, first: $first, skip: $skip) {
@@ -24,7 +24,7 @@ export const ALL_VOTES = (type: string) => gql`
 `
 
 export const CASTS_FOR_VOTE = (type: string) => gql`
-  query Casts($voteId: ID!, $first: Int!, $skip: Int!) {
+  ${type} Casts($voteId: ID!, $first: Int!, $skip: Int!) {
     casts(where: {
       voteId: $voteId
     }, first: $first, skip: $skip) {

--- a/packages/connect-voting/src/thegraph/queries/index.ts
+++ b/packages/connect-voting/src/thegraph/queries/index.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 export const ALL_VOTES = (type: string) => gql`
-  ${type} Votes($appAddress: String!, $first: Int!, $skip: Int!) {
+  query Votes($appAddress: String!, $first: Int!, $skip: Int!) {
     votes(where: {
       appAddress: $appAddress
     }, first: $first, skip: $skip) {
@@ -24,7 +24,7 @@ export const ALL_VOTES = (type: string) => gql`
 `
 
 export const CASTS_FOR_VOTE = (type: string) => gql`
-  ${type} Casts($voteId: ID!, $first: Int!, $skip: Int!) {
+  query Casts($voteId: ID!, $first: Int!, $skip: Int!) {
     casts(where: {
       voteId: $voteId
     }, first: $first, skip: $skip) {

--- a/packages/connect/src/connect.ts
+++ b/packages/connect/src/connect.ts
@@ -28,7 +28,10 @@ export type ConnectOptions = {
 
 export type ConnectorDeclaration =
   | IOrganizationConnector
-  | [string, object | undefined]
+  | ['ethereum', ConnectorEthereumConfig | undefined]
+  | ['json', ConnectorJsonConfig | undefined]
+  | ['thegraph', ConnectorTheGraphConfig | undefined]
+  | [string, any]
   | string
 
 type IpfsResolver = (cid: string, path?: string) => string

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,7 +1992,7 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
-"@types/estree@*", "@types/estree@^0.0.45":
+"@types/estree@*":
   version "0.0.45"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
   integrity sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==
@@ -2055,7 +2055,7 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4":
+"@types/json-schema@^7.0.3":
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
@@ -2495,12 +2495,12 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn@^6.0.1, acorn@^6.0.4:
+acorn@^6.0.1, acorn@^6.0.4, acorn@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^7.1.1, acorn@^7.3.0, acorn@^7.3.1:
+acorn@^7.1.1, acorn@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
@@ -2533,7 +2533,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.1.tgz#b83ca89c5d42d69031f424cad49aada0236c6957"
   integrity sha512-KWcq3xN8fDjSB+IMoh2VaXVhRI0BBGxoYp3rx7Pkb6z0cFjYR9Q9l4yZqqals0/zsioCmocC5H6UvsGD4MoIBA==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
   version "6.12.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
   integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
@@ -2637,6 +2637,11 @@ anymatch@^3.0.3, anymatch@~3.1.1:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+aproba@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
 arg@^4.1.0:
   version "4.1.3"
@@ -3277,7 +3282,28 @@ bytes@3.1.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
-cacache@^15.0.0, cacache@^15.0.5:
+cacache@^12.0.2:
+  version "12.0.4"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.4.tgz#668bcbd105aeb5f1d92fe25570ec9525c8faa40c"
+  integrity sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==
+  dependencies:
+    bluebird "^3.5.5"
+    chownr "^1.1.1"
+    figgy-pudding "^3.5.1"
+    glob "^7.1.4"
+    graceful-fs "^4.1.15"
+    infer-owner "^1.0.3"
+    lru-cache "^5.1.1"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    promise-inflight "^1.0.1"
+    rimraf "^2.6.3"
+    ssri "^6.0.1"
+    unique-filename "^1.1.1"
+    y18n "^4.0.0"
+
+cacache@^15.0.0:
   version "15.0.5"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.0.5.tgz#69162833da29170d6732334643c60e005f5f17d0"
   integrity sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==
@@ -3496,6 +3522,26 @@ chokidar@^3.4.0:
     readdirp "~3.4.0"
   optionalDependencies:
     fsevents "~2.1.2"
+
+chokidar@^3.4.1:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
+  integrity sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -3747,7 +3793,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@~1.6.0:
+concat-stream@^1.5.0, concat-stream@~1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -3800,6 +3846,18 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+copy-concurrently@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
+  integrity sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==
+  dependencies:
+    aproba "^1.1.1"
+    fs-write-stream-atomic "^1.0.8"
+    iferr "^0.1.5"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.4"
+    run-queue "^1.0.0"
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -4119,6 +4177,11 @@ csstype@^2.2.0, csstype@^2.5.7:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
   integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
+
+cyclist@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
+  integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -4501,6 +4564,16 @@ duplexer@^0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
+duplexify@^3.4.2, duplexify@^3.6.0:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
+  integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
+  dependencies:
+    end-of-stream "^1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -4557,22 +4630,14 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@5.0.0-beta.8:
-  version "5.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.8.tgz#f399920cb9f73350e61ab10bf2c7f36c37dbf032"
-  integrity sha512-6MteIR5h29V8UAsBVXkW7P2cAf+5p/c+Gu79xNCpBPt+hgKcJ0vujcX4vAiMGJjyq3SCHaY5N64C8HXwwRS3gQ==
-  dependencies:
-    graceful-fs "^4.2.0"
-    tapable "^2.0.0-beta.10"
-
-enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1:
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz#3b806f3bfafc1ec7de69551ef93cca46c1704126"
   integrity sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==
@@ -4603,7 +4668,7 @@ envinfo@^7.3.1:
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.7.2.tgz#098f97a0e902f8141f9150553c92dbb282c4cabe"
   integrity sha512-k3Eh5bKuQnZjm49/L7H4cHzs2FlL5QjbTB3JrPxoTI8aJG7hVMe4uKyJxSYH4ahseby2waUwk5OaKX/nAsaYgg==
 
-errno@^0.1.3:
+errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   integrity sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
@@ -4696,6 +4761,14 @@ escodegen@~1.9.0:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+eslint-scope@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^5.0.0, eslint-scope@^5.1.0:
   version "5.1.0"
@@ -5176,6 +5249,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+figgy-pudding@^3.5.1:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
+  integrity sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -5237,6 +5315,15 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
+find-cache-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
+  integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^2.0.0"
+    pkg-dir "^3.0.0"
+
 find-cache-dir@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
@@ -5290,6 +5377,14 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
+flush-write-stream@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
+  integrity sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.3.6"
+
 follow-redirects@^1.0.0:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.12.1.tgz#de54a6205311b93d60398ebc01cf7015682312b6"
@@ -5336,12 +5431,30 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
+from2@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  integrity sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
   integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
   dependencies:
     minipass "^3.0.0"
+
+fs-write-stream-atomic@^1.0.8:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
+  integrity sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=
+  dependencies:
+    graceful-fs "^4.1.2"
+    iferr "^0.1.5"
+    imurmurhash "^0.1.4"
+    readable-stream "1 || 2"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -5442,11 +5555,6 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob-to-regexp@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
-  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
-
 glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -5535,7 +5643,7 @@ got@^11.1.4:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -5933,6 +6041,11 @@ ieee754@^1.1.4:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
+iferr@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
+  integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
+
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
@@ -5985,7 +6098,7 @@ indexes-of@^1.0.1:
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
   integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
 
-infer-owner@^1.0.4:
+infer-owner@^1.0.3, infer-owner@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
@@ -7183,10 +7296,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-loader-runner@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.0.0.tgz#02abcfd9fe6ff7a5aeb3547464746c4dc6ba333d"
-  integrity sha512-Rqf48ufrr48gFjnaqss04QesoXB7VenbpFFIV/0yOKGnpbejrVlOPqTsoX42FG5goXM5Ixekcs4DqDzHOX2z7Q==
+loader-runner@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
+  integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
 loader-utils@^1.0.2, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
@@ -7283,6 +7396,13 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -7303,6 +7423,14 @@ magic-string@^0.25.2, magic-string@^0.25.5:
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
   dependencies:
     sourcemap-codec "^1.4.4"
+
+make-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
 
 make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
@@ -7537,6 +7665,22 @@ minizlib@^2.1.0:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
+mississippi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
+  integrity sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==
+  dependencies:
+    concat-stream "^1.5.0"
+    duplexify "^3.4.2"
+    end-of-stream "^1.1.0"
+    flush-write-stream "^1.0.0"
+    from2 "^2.1.0"
+    parallel-transform "^1.1.0"
+    pump "^3.0.0"
+    pumpify "^1.3.3"
+    stream-each "^1.1.0"
+    through2 "^2.0.0"
+
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -7550,12 +7694,24 @@ mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+move-concurrently@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
+  integrity sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=
+  dependencies:
+    aproba "^1.1.1"
+    copy-concurrently "^1.0.0"
+    fs-write-stream-atomic "^1.0.8"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.4"
+    run-queue "^1.0.3"
 
 ms@2.0.0:
   version "2.0.0"
@@ -7627,7 +7783,7 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-neo-async@^2.6.1:
+neo-async@^2.5.0, neo-async@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -7680,7 +7836,7 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
-node-libs-browser@^2.0.0:
+node-libs-browser@^2.0.0, node-libs-browser@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
   integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
@@ -8045,13 +8201,6 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
-  integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
-  dependencies:
-    p-try "^2.0.0"
-
 p-locate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
@@ -8114,6 +8263,15 @@ pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
+parallel-transform@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.2.0.tgz#9049ca37d6cb2182c3b1d2c720be94d14a5814fc"
+  integrity sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==
+  dependencies:
+    cyclist "^1.0.1"
+    inherits "^2.0.3"
+    readable-stream "^2.1.5"
 
 param-case@^3.0.3:
   version "3.0.3"
@@ -8810,6 +8968,11 @@ pretty-format@^26.1.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+printable-characters@^1.0.26, printable-characters@^1.0.42:
+  version "1.0.42"
+  resolved "https://registry.yarnpkg.com/printable-characters/-/printable-characters-1.0.42.tgz#3f18e977a9bd8eb37fcc4ff5659d7be90868b3d8"
+  integrity sha1-Pxjpd6m9jrN/zE/1ZZ176Qhos9g=
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -8889,6 +9052,14 @@ public-encrypt@^4.0.0:
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
 
+pump@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  integrity sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -8896,6 +9067,15 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+pumpify@^1.3.3:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
+  integrity sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==
+  dependencies:
+    duplexify "^3.6.0"
+    inherits "^2.0.3"
+    pump "^2.0.0"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -9068,7 +9248,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.3, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.3, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -9389,7 +9569,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -9427,6 +9607,13 @@ run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+
+run-queue@^1.0.0, run-queue@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
+  integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
+  dependencies:
+    aproba "^1.1.1"
 
 rxjs@^6.4.0, rxjs@^6.6.0:
   version "6.6.0"
@@ -9508,15 +9695,6 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.5.0, schema-utils@^2.6.6:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
-  integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
-  dependencies:
-    "@types/json-schema" "^7.0.4"
-    ajv "^6.12.2"
-    ajv-keywords "^3.4.1"
-
 scrypt-js@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
@@ -9534,7 +9712,7 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "0.9.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -9823,7 +10001,7 @@ sockjs@0.3.20:
     uuid "^3.4.0"
     websocket-driver "0.6.5"
 
-source-list-map@^2.0.0, source-list-map@^2.0.1:
+source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
@@ -9955,6 +10133,13 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
+ssri@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
+  integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
+  dependencies:
+    figgy-pudding "^3.5.1"
+
 ssri@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.0.tgz#79ca74e21f8ceaeddfcb4b90143c458b8d988808"
@@ -10061,6 +10246,14 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
+stream-each@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae"
+  integrity sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==
+  dependencies:
+    end-of-stream "^1.1.0"
+    stream-shift "^1.0.0"
+
 stream-http@^2.7.2:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
@@ -10071,6 +10264,11 @@ stream-http@^2.7.2:
     readable-stream "^2.3.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
+
+stream-shift@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
+  integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
 string-kit@^0.5.12:
   version "0.5.27"
@@ -10113,6 +10311,21 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string.bullet@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/string.bullet/-/string.bullet-1.0.12.tgz#b41fc417850a57e4042bf3cf347b6eee257ee253"
+  integrity sha1-tB/EF4UKV+QEK/PPNHtu7iV+4lM=
+  dependencies:
+    printable-characters "^1.0.26"
+
+string.ify@^1.0.64:
+  version "1.0.64"
+  resolved "https://registry.yarnpkg.com/string.ify/-/string.ify-1.0.64.tgz#58de9fcc411a26bb61f83bf61a1a756da0966c3b"
+  integrity sha512-4Aa5yndnuOhE1GV2W3ht4rQ08XHq46JLXmSOv0jeUWEzqliBvm8lAXvt+66np+J9DkoCZikFzTzjXVLRR0F/Xw==
+  dependencies:
+    printable-characters "^1.0.42"
+    string.bullet "^1.0.12"
 
 string.prototype.trimend@^1.0.1:
   version "1.0.1"
@@ -10302,11 +10515,6 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tapable@^2.0.0-beta.10:
-  version "2.0.0-beta.11"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.0.0-beta.11.tgz#5a6bd5e0353fad4da9e94942206bb596639e8cf7"
-  integrity sha512-cAhRzCvMdyJsxmdrSXG8/SUlJG4WJUxD/csuYAybUFjKVt74Y6pTyZ/I1ZK+enmCkWZN0JWxh14G69temaGSiA==
-
 tar@^6.0.1, tar@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.2.tgz#5df17813468a6264ff14f766886c622b84ae2f39"
@@ -10337,20 +10545,20 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser-webpack-plugin@^3.0.2:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-3.0.7.tgz#db23b946dcca8954da3ebda3675360bceebdc78e"
-  integrity sha512-5JqibUOctE6Ou4T00IVGYTQJBOhu24jz0PpqYeitQJJ3hlZY2ZKSwzzuqjmBH8MzbdWMgIefpmHwTkvwm6Q4CQ==
+terser-webpack-plugin@^1.4.3:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz#a217aefaea330e734ffacb6120ec1fa312d6040b"
+  integrity sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==
   dependencies:
-    cacache "^15.0.5"
-    find-cache-dir "^3.3.1"
-    jest-worker "^26.1.0"
-    p-limit "^3.0.2"
-    schema-utils "^2.6.6"
+    cacache "^12.0.2"
+    find-cache-dir "^2.1.0"
+    is-wsl "^1.1.0"
+    schema-utils "^1.0.0"
     serialize-javascript "^4.0.0"
     source-map "^0.6.1"
-    terser "^4.8.0"
-    webpack-sources "^1.4.3"
+    terser "^4.1.2"
+    webpack-sources "^1.4.0"
+    worker-farm "^1.7.0"
 
 terser@^3.7.3:
   version "3.17.0"
@@ -10361,7 +10569,7 @@ terser@^3.7.3:
     source-map "~0.6.1"
     source-map-support "~0.5.10"
 
-terser@^4.6.3, terser@^4.8.0:
+terser@^4.1.2, terser@^4.6.3, terser@^4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
   integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
@@ -10953,13 +11161,23 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-watchpack@2.0.0-beta.13:
-  version "2.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.0.0-beta.13.tgz#9d9b0c094b8402139333e04eb6194643c8384f55"
-  integrity sha512-ZEFq2mx/k5qgQwgi6NOm+2ImICb8ngAkA/rZ6oyXZ7SgPn3pncf+nfhYTCrs3lmHwOxnPtGLTOuFLfpSMh1VMA==
+watchpack-chokidar2@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz#9948a1866cbbd6cb824dea13a7ed691f6c8ddff0"
+  integrity sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==
   dependencies:
-    glob-to-regexp "^0.4.1"
+    chokidar "^2.1.8"
+
+watchpack@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.4.tgz#6e9da53b3c80bb2d6508188f5b200410866cd30b"
+  integrity sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==
+  dependencies:
     graceful-fs "^4.1.2"
+    neo-async "^2.5.0"
+  optionalDependencies:
+    chokidar "^3.4.1"
+    watchpack-chokidar2 "^2.0.0"
 
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
@@ -11084,15 +11302,7 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
-webpack-sources@2.0.0-beta.8:
-  version "2.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.0.0-beta.8.tgz#0fc292239f6767cf4e9b47becfaa340ce6d7ea4f"
-  integrity sha512-RUaCJu7HYNeuzlY4WYcArcnOzMIj7kHndQ4pBdgP3iiMpG3Ke0BWY5wvb/VEFgsIXp3ZzPGRECwX+4fgpcKFYw==
-  dependencies:
-    source-list-map "^2.0.1"
-    source-map "~0.6.1"
-
-webpack-sources@^1.4.3:
+webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
@@ -11100,33 +11310,34 @@ webpack-sources@^1.4.3:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^5.0.0-beta.15:
-  version "5.0.0-beta.22"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.0.0-beta.22.tgz#c5560c3b470ccab69c66273a3bcf314f85926bea"
-  integrity sha512-t3HnQPy88PASM2ur0rvUXau8vAz287BlH8DpiaHoWkjlLThLx7olzExtTsVJEFen/9uTfWOV21dWS8kiYmGLkA==
+webpack@^4.44.1:
+  version "4.44.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.1.tgz#17e69fff9f321b8f117d1fda714edfc0b939cc21"
+  integrity sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==
   dependencies:
-    "@types/estree" "^0.0.45"
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/helper-module-context" "1.9.0"
     "@webassemblyjs/wasm-edit" "1.9.0"
     "@webassemblyjs/wasm-parser" "1.9.0"
-    acorn "^7.3.0"
+    acorn "^6.4.1"
+    ajv "^6.10.2"
+    ajv-keywords "^3.4.1"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "5.0.0-beta.8"
-    eslint-scope "^5.0.0"
-    events "^3.0.0"
-    glob-to-regexp "^0.4.1"
-    graceful-fs "^4.1.15"
+    enhanced-resolve "^4.3.0"
+    eslint-scope "^4.0.3"
     json-parse-better-errors "^1.0.2"
-    loader-runner "^4.0.0"
-    mime-types "^2.1.26"
+    loader-runner "^2.4.0"
+    loader-utils "^1.2.3"
+    memory-fs "^0.4.1"
+    micromatch "^3.1.10"
+    mkdirp "^0.5.3"
     neo-async "^2.6.1"
-    pkg-dir "^4.2.0"
-    schema-utils "^2.5.0"
-    tapable "^2.0.0-beta.10"
-    terser-webpack-plugin "^3.0.2"
-    watchpack "2.0.0-beta.13"
-    webpack-sources "2.0.0-beta.8"
+    node-libs-browser "^2.2.1"
+    schema-utils "^1.0.0"
+    tapable "^1.1.3"
+    terser-webpack-plugin "^1.4.3"
+    watchpack "^1.7.4"
+    webpack-sources "^1.4.1"
 
 websocket-driver@0.6.5:
   version "0.6.5"
@@ -11212,6 +11423,13 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+worker-farm@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz#26a94c5391bbca926152002f69b84a4bf772e5a8"
+  integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
+  dependencies:
+    errno "~0.1.7"
 
 wrap-ansi@^5.1.0:
   version "5.1.0"
@@ -11306,6 +11524,11 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
The Graph is having issues with GraphQL subscriptions, so we are moving to queries with polling for the time being. Once subscriptions get enabled again on The Graph, we will move back to GraphQL subscriptions.

Also in this PR:
- `nodejs/` demos update.
- Add the possibility to consume the organization connector from any app   connector, allowing to retrieve its options for example. This was done so that app connectors using TheGraph can inherit from pollInterval defined in the main connector.
