### PR TITLE
Move to Node-style callbacks in every subscription

### DIFF
--- a/docs/advanced/low-level-queries.md
+++ b/docs/advanced/low-level-queries.md
@@ -72,7 +72,9 @@ const subscription = wrapper.subscribeToQuery(
     id: TOKEN_ID,
     address: ACCOUNT_ADDRES,
   },
-  results => {
+  (error, results) => {
+    if (error) throw error
+
     // Handle each new result
     const { miniMeToken } = results.data
   }

--- a/docs/connectors/finance-app.md
+++ b/docs/connectors/finance-app.md
@@ -33,13 +33,13 @@ Get the list of transactions in the Finance app.
 
 Subscribe to the list of transactions in the Finance app.
 
-| Name            | Type                   | Description                                                         |
-| --------------- | ---------------------- | ------------------------------------------------------------------- |
-| `filters`       | `Object`               | Optional object allowing to filter the votes.                       |
-| `filters.first` | `Number`               | Maximum number of votes. Defaults to `1000`.                        |
-| `filters.skip`  | `Number`               | Skip a number of votes. Defaults to `0`.                            |
-| `callback`      | `transactions => void` | A callback that will get called every time the result gets updated. |
-| returns         | `Function`             | Unsubscribe function.                                               |
+| Name            | Type                                                  | Description                                                         |
+| --------------- | ----------------------------------------------------- | ------------------------------------------------------------------- |
+| `filters`       | `Object`                                              | Optional object allowing to filter the votes.                       |
+| `filters.first` | `Number`                                              | Maximum number of votes. Defaults to `1000`.                        |
+| `filters.skip`  | `Number`                                              | Skip a number of votes. Defaults to `0`.                            |
+| `callback`      | `(error: Error, transactions: Transaction[]) => void` | A callback that will get called every time the result gets updated. |
+| returns         | `{ unsubscribe: () => void }`                         | Unsubscribe function.                                               |
 
 ### Finance\#balance\(tokenAddress, filters\)
 
@@ -57,11 +57,11 @@ Get the balance of a token in the Finance app.
 
 Subscribe to the balance of a token in the Finance app.
 
-| Name            | Type              | Description                                                         |
-| --------------- | ----------------- | ------------------------------------------------------------------- |
-| `tokenAddress`  | `String`          | The address of the token.                                           |
-| `filters`       | `Object`          | Optional object allowing to filter the votes.                       |
-| `filters.first` | `Number`          | Maximum number of votes. Defaults to `1000`.                        |
-| `filters.skip`  | `Number`          | Skip a number of votes. Defaults to `0`.                            |
-| `callback`      | `balance => void` | A callback that will get called every time the result gets updated. |
-| returns         | `Function`        | Unsubscribe function.                                               |
+| Name            | Type                                            | Description                                                         |
+| --------------- | ----------------------------------------------- | ------------------------------------------------------------------- |
+| `tokenAddress`  | `String`                                        | The address of the token.                                           |
+| `filters`       | `Object`                                        | Optional object allowing to filter the votes.                       |
+| `filters.first` | `Number`                                        | Maximum number of votes. Defaults to `1000`.                        |
+| `filters.skip`  | `Number`                                        | Skip a number of votes. Defaults to `0`.                            |
+| `callback`      | `(error: Error, balance: TokenBalance) => void` | A callback that will get called every time the result gets updated. |
+| returns         | `{ unsubscribe: () => void }`                   | Unsubscribe function.                                               |

--- a/docs/connectors/organizations.md
+++ b/docs/connectors/organizations.md
@@ -2,7 +2,7 @@
 
 This is the main connector of the Aragon Connect library. It is responsible for parsing the organization’s data.
 
-Currently a single flavor of this connector is available and comes built into the core library, connecting to a Subgraph data source,. We have plans to expand to other flavors, like an Ethereum connector that reduces the state directly from an Ethereum node’s JSON-RPC API, or a SQL connector that fetches data from a database, etc.
+Currently a single flavor of this connector is available and comes built into the core library, connecting to a Subgraph (The Graph) data source,. We have plans to expand to other flavors, like an Ethereum connector that reduces the state directly from an Ethereum node’s JSON-RPC API, or a SQL connector that fetches data from a database, etc.
 
 ## Connector Interface
 
@@ -40,35 +40,35 @@ Perform a GraphQL query.
 
 Perform a GraphQL query and parse the result.
 
-| Name     | Type           | Description                                       |
-| -------- | -------------- | ------------------------------------------------- |
-| `query`  | `DocumentNode` | GraphQL query parsed in the standard GraphQL AST. |
-| `args`   | `any = {}`     | Arguments to pass to fields in the query.         |
-| `parser` | `Function`     | Parser function.                                  |
-| returns  | `Promise<any>` | Query result data parsed.                         |
+| Name     | Type                 | Description                                       |
+| -------- | -------------------- | ------------------------------------------------- |
+| `query`  | `DocumentNode`       | GraphQL query parsed in the standard GraphQL AST. |
+| `args`   | `any = {}`           | Arguments to pass to fields in the query.         |
+| `parser` | `(data: any) => any` | Parser function.                                  |
+| returns  | `Promise<any>`       | Query result data parsed.                         |
 
 **GraphQLWrapper\#subscribeToQuery\(query, args, callback\)**
 
 Create a GraphQL subscription.
 
-| Name       | Type                          | Description                                       |
-| ---------- | ----------------------------- | ------------------------------------------------- |
-| `query`    | `DocumentNode`                | GraphQL query parsed in the standard GraphQL AST. |
-| `args`     | `any = {}`                    | Arguments to pass to fields in the query.         |
-| `callback` | `Function`                    | Callback function call on every data update.      |
-| returns    | `{ unsubscribe: () => void }` | Subscription handler.                             |
+| Name       | Type                                          | Description                                       |
+| ---------- | --------------------------------------------- | ------------------------------------------------- |
+| `query`    | `DocumentNode`                                | GraphQL query parsed in the standard GraphQL AST. |
+| `args`     | `any = {}`                                    | Arguments to pass to fields in the query.         |
+| `callback` | `(error: Error, result: QueryResult) => void` | Callback function call on every data update.      |
+| returns    | `{ unsubscribe: () => void }`                 | Subscription handler.                             |
 
 **GraphQLWrapper\#subscribeToQueryWithParser\(query, args, callback, parser\)**
 
 Create a GraphQL subscription and parse the emitted results.
 
-| Name       | Type                          | Description                                       |
-| ---------- | ----------------------------- | ------------------------------------------------- |
-| `query`    | `DocumentNode`                | GraphQL query parsed in the standard GraphQL AST. |
-| `args`     | `any = {}`                    | Arguments to pass to fields in the query.         |
-| `callback` | `Function`                    | Callback function call on every data update.      |
-| `parser`   | `Function`                    | Parser function.                                  |
-| returns    | `{ unsubscribe: () => void }` | Subscription handler.                             |
+| Name       | Type                                  | Description                                       |
+| ---------- | ------------------------------------- | ------------------------------------------------- |
+| `query`    | `DocumentNode`                        | GraphQL query parsed in the standard GraphQL AST. |
+| `args`     | `any = {}`                            | Arguments to pass to fields in the query.         |
+| `callback` | `(error: Error, result: any) => void` | Callback function call on every data update.      |
+| `parser`   | `(data: any) => any`                  | Parser function.                                  |
+| returns    | `{ unsubscribe: () => void }`         | Subscription handler.                             |
 
 ### Subgraph Schema
 

--- a/docs/connectors/tokens-app.md
+++ b/docs/connectors/tokens-app.md
@@ -52,10 +52,10 @@ Get a list of token holders.
 
 Subscribe to a list of token holders.
 
-| Name            | Type                                                 | Description                                                         |
-| --------------- | ---------------------------------------------------- | ------------------------------------------------------------------- |
-| `filters`       | `Object`                                             | Optional object allowing to filter the token holders.               |
-| `filters.first` | `Number`                                             | Maximum number of token holders. Defaults to `1000`.                |
-| `filters.skip`  | `Number`                                             | Skip a number of token holders. Defaults to `0`.                    |
+| Name            | Type                                                  | Description                                                         |
+| --------------- | ----------------------------------------------------- | ------------------------------------------------------------------- |
+| `filters`       | `Object`                                              | Optional object allowing to filter the token holders.               |
+| `filters.first` | `Number`                                              | Maximum number of token holders. Defaults to `1000`.                |
+| `filters.skip`  | `Number`                                              | Skip a number of token holders. Defaults to `0`.                    |
 | `callback`      | `(error: Error, tokenHolders: TokenHolder[]) => void` | A callback that will get called every time the result gets updated. |
-| returns         | `{ unsubscribe: () => void }`                        | Unsubscribe function.                                               |
+| returns         | `{ unsubscribe: () => void }`                         | Unsubscribe function.                                               |

--- a/docs/connectors/tokens-app.md
+++ b/docs/connectors/tokens-app.md
@@ -52,10 +52,10 @@ Get a list of token holders.
 
 Subscribe to a list of token holders.
 
-| Name            | Type                   | Description                                                         |
-| --------------- | ---------------------- | ------------------------------------------------------------------- |
-| `filters`       | `Object`               | Optional object allowing to filter the token holders.               |
-| `filters.first` | `Number`               | Maximum number of token holders. Defaults to `1000`.                |
-| `filters.skip`  | `Number`               | Skip a number of token holders. Defaults to `0`.                    |
-| `callback`      | `tokenHolders => void` | A callback that will get called every time the result gets updated. |
-| returns         | `Function`             | Unsubscribe function.                                               |
+| Name            | Type                                                 | Description                                                         |
+| --------------- | ---------------------------------------------------- | ------------------------------------------------------------------- |
+| `filters`       | `Object`                                             | Optional object allowing to filter the token holders.               |
+| `filters.first` | `Number`                                             | Maximum number of token holders. Defaults to `1000`.                |
+| `filters.skip`  | `Number`                                             | Skip a number of token holders. Defaults to `0`.                    |
+| `callback`      | `(error: Error, tokenHolders: TokenHolder[]) => void` | A callback that will get called every time the result gets updated. |
+| returns         | `{ unsubscribe: () => void }`                        | Unsubscribe function.                                               |

--- a/docs/connectors/voting-app.md
+++ b/docs/connectors/voting-app.md
@@ -33,10 +33,10 @@ Get the list of votes in the Voting app.
 
 Subscribe to the list of votes in the Voting app.
 
-| Name            | Type            | Description                                                         |
-| --------------- | --------------- | ------------------------------------------------------------------- |
-| `filters`       | `Object`        | Optional object allowing to filter the votes.                       |
-| `filters.first` | `Number`        | Maximum number of votes. Defaults to `1000`.                        |
-| `filters.skip`  | `Number`        | Skip a number of votes. Defaults to `0`.                            |
-| `callback`      | `votes => void` | A callback that will get called every time the result gets updated. |
-| returns         | `Function`      | Unsubscribe function.                                               |
+| Name            | Type                                    | Description                                                         |
+| --------------- | --------------------------------------- | ------------------------------------------------------------------- |
+| `filters`       | `Object`                                | Optional object allowing to filter the votes.                       |
+| `filters.first` | `Number`                                | Maximum number of votes. Defaults to `1000`.                        |
+| `filters.skip`  | `Number`                                | Skip a number of votes. Defaults to `0`.                            |
+| `callback`      | `(error: Error, votes: Vote[]) => void` | A callback that will get called every time the result gets updated. |
+| returns         | `{ unsubscribe: () => void }`           | Unsubscribe function.                                               |

--- a/examples/nodejs/src/subscriptions-low-level.ts
+++ b/examples/nodejs/src/subscriptions-low-level.ts
@@ -24,7 +24,11 @@ async function main() {
       }
     `,
     {},
-    (results: any) => {
+    (error: Error | null, results?: any) => {
+      if (error) {
+        console.error(error)
+        return
+      }
       console.log(JSON.stringify(results.data, null, 2))
       console.log(
         `\nTry creating a new vote at https://rinkeby.aragon.org/#/${DAO_ADDRESS}/${VOTING_APP_ADDRESS}/`

--- a/examples/nodejs/src/subscriptions-org.ts
+++ b/examples/nodejs/src/subscriptions-org.ts
@@ -8,12 +8,20 @@ async function main() {
     network: 4,
   })) as Organization
 
-  const subscription = org.onPermissions((permissions: Permission[]) => {
-    permissions.map(console.log)
-    console.log(
-      `\nTry creating or granting new permissions at https://rinkeby.aragon.org/#/${ORG_ADDRESS}/permissions/`
-    )
-  })
+  const subscription = org.onPermissions(
+    (error: Error | null, permissions?: Permission[]) => {
+      if (error) {
+        console.error(error)
+        return
+      }
+      for (const permission of permissions as Permission[]) {
+        console.log(permission)
+      }
+      console.log(
+        `\nTry creating or granting new permissions at https://rinkeby.aragon.org/#/${ORG_ADDRESS}/permissions/`
+      )
+    }
+  )
 
   await keepRunning()
 

--- a/examples/nodejs/src/subscriptions-tokens.ts
+++ b/examples/nodejs/src/subscriptions-tokens.ts
@@ -13,10 +13,18 @@ async function main() {
   console.log(`\nToken:`)
   console.log(token)
 
-  const subscription = tokens.onHolders((holders: TokenHolder[]) => {
-    console.log(`\nHolders:`)
-    holders.map(console.log)
-  })
+  const subscription = tokens.onHolders(
+    (error: Error | null, holders?: TokenHolder[]) => {
+      if (error) {
+        console.error(error)
+        return
+      }
+      console.log(`\nHolders:`)
+      for (const holder of holders as TokenHolder[]) {
+        console.log(holder)
+      }
+    }
+  )
 
   // await keepRunning()
 

--- a/examples/nodejs/src/subscriptions-voting.ts
+++ b/examples/nodejs/src/subscriptions-voting.ts
@@ -9,35 +9,52 @@ async function main() {
   const org = await connect(ORG_ADDRESS, 'thegraph', { network: 4 })
   const voting = await connectVoting(org.app(VOTING_APP_ADDRESS))
 
-  const votesSubscription = voting.onVotes({}, (votes: Vote[]) => {
-    console.log('\nVotes: ')
-    votes
-      .map((vote, index) => ({
-        index,
-        title: vote.metadata,
-        id: vote.id,
-      }))
-      .forEach((vote) => {
-        console.log(vote)
-      })
-    console.log(
-      `\nTry creating a new vote at https://rinkeby.aragon.org/#/${ORG_ADDRESS}/${VOTING_APP_ADDRESS}/\n`
-    )
-  })
+  const votesSubscription = voting.onVotes(
+    {},
+    (error: Error | null, votes?: Vote[]) => {
+      if (error) {
+        console.error(error)
+        return
+      }
+      console.log('\nVotes: ')
+
+      votes = votes as Vote[]
+
+      votes
+        .map((vote, index) => ({
+          index,
+          title: vote.metadata,
+          id: vote.id,
+        }))
+        .forEach((vote) => {
+          console.log(vote)
+        })
+
+      console.log(
+        `\nTry creating a new vote at https://rinkeby.aragon.org/#/${ORG_ADDRESS}/${VOTING_APP_ADDRESS}/\n`
+      )
+    }
+  )
 
   const votes = await voting.votes()
   const vote1 = votes[1]
   console.log(`Vote #1: `, vote1)
 
-  const castsSubscription = vote1.onCasts((casts: Cast[]) => {
-    console.log(`\nCasts:`)
-    casts.forEach((cast) => {
-      console.log(cast)
-    })
-    console.log(
-      `\nTry casting a vote on https://rinkeby.aragon.org/#/${ORG_ADDRESS}/${VOTING_APP_ADDRESS}/vote/1 (You must first mint yourself a token in the Token Manager)\n`
-    )
-  })
+  const castsSubscription = vote1.onCasts(
+    (error: Error | null, casts?: Cast[]) => {
+      if (error) {
+        console.error(error)
+        return
+      }
+      console.log(`\nCasts:`)
+      for (const cast of casts as Cast[]) {
+        console.log(cast)
+      }
+      console.log(
+        `\nTry casting a vote on https://rinkeby.aragon.org/#/${ORG_ADDRESS}/${VOTING_APP_ADDRESS}/vote/1 (You must first mint yourself a token in the Token Manager)\n`
+      )
+    }
+  )
 
   await keepRunning()
 

--- a/packages/connect-agreement/src/models/Agreement.ts
+++ b/packages/connect-agreement/src/models/Agreement.ts
@@ -1,4 +1,8 @@
-import { Address, SubscriptionHandler } from '@aragon/connect-types'
+import {
+  Address,
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 
 import Signer from './Signer'
 import Version from './Version'
@@ -36,7 +40,9 @@ export default class Agreement {
     return this.#connector.currentVersion(this.#address)
   }
 
-  onCurrentVersion(callback: Function): SubscriptionHandler {
+  onCurrentVersion(
+    callback: SubscriptionCallback<Version>
+  ): SubscriptionHandler {
     return this.#connector.onCurrentVersion(this.#address, callback)
   }
 
@@ -48,7 +54,10 @@ export default class Agreement {
     return this.#connector.version(this.versionId(versionNumber))
   }
 
-  onVersion(versionNumber: string, callback: Function): SubscriptionHandler {
+  onVersion(
+    versionNumber: string,
+    callback: SubscriptionCallback<Version>
+  ): SubscriptionHandler {
     return this.#connector.onVersion(this.versionId(versionNumber), callback)
   }
 
@@ -58,7 +67,7 @@ export default class Agreement {
 
   onVersions(
     { first = 1000, skip = 0 } = {},
-    callback: Function
+    callback: SubscriptionCallback<Version[]>
   ): SubscriptionHandler {
     return this.#connector.onVersions(this.#address, first, skip, callback)
   }
@@ -71,7 +80,10 @@ export default class Agreement {
     return this.#connector.signer(this.signerId(signerAddress))
   }
 
-  onSigner(signerAddress: string, callback: Function): SubscriptionHandler {
+  onSigner(
+    signerAddress: string,
+    callback: SubscriptionCallback<Signer>
+  ): SubscriptionHandler {
     return this.#connector.onSigner(this.signerId(signerAddress), callback)
   }
 }

--- a/packages/connect-agreement/src/models/Signer.ts
+++ b/packages/connect-agreement/src/models/Signer.ts
@@ -1,4 +1,7 @@
-import { SubscriptionHandler } from '@aragon/connect-types'
+import {
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 
 import Signature from '../models/Signature'
 import { SignerData, IAgreementConnector } from '../types'
@@ -36,7 +39,7 @@ export default class Signer {
 
   onSignatures(
     { first = 1000, skip = 0 } = {},
-    callback: Function
+    callback: SubscriptionCallback<Signature[]>
   ): SubscriptionHandler {
     return this.#connector.onSignatures(this.id, first, skip, callback)
   }

--- a/packages/connect-agreement/src/thegraph/connector.ts
+++ b/packages/connect-agreement/src/thegraph/connector.ts
@@ -1,4 +1,7 @@
-import { SubscriptionHandler } from '@aragon/connect-types'
+import {
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import { GraphQLWrapper, QueryResult } from '@aragon/connect-thegraph'
 
 import * as queries from './queries'
@@ -54,15 +57,18 @@ export default class AgreementConnectorTheGraph implements IAgreementConnector {
   }
 
   async agreement(agreement: string): Promise<AgreementData> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<AgreementData>(
       queries.GET_AGREEMENT('query'),
       { agreement },
       (result: QueryResult) => parseAgreement(result)
     )
   }
 
-  onAgreement(agreement: string, callback: Function): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+  onAgreement(
+    agreement: string,
+    callback: SubscriptionCallback<AgreementData>
+  ): SubscriptionHandler {
+    return this.#gql.subscribeToQueryWithParser<AgreementData>(
       queries.GET_AGREEMENT('subscription'),
       { agreement },
       callback,
@@ -71,15 +77,18 @@ export default class AgreementConnectorTheGraph implements IAgreementConnector {
   }
 
   async currentVersion(agreement: string): Promise<Version> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Version>(
       queries.GET_CURRENT_VERSION('query'),
       { agreement },
       (result: QueryResult) => parseCurrentVersion(result, this)
     )
   }
 
-  onCurrentVersion(agreement: string, callback: Function): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+  onCurrentVersion(
+    agreement: string,
+    callback: SubscriptionCallback<Version>
+  ): SubscriptionHandler {
+    return this.#gql.subscribeToQueryWithParser<Version>(
       queries.GET_CURRENT_VERSION('subscription'),
       { agreement },
       callback,
@@ -88,15 +97,18 @@ export default class AgreementConnectorTheGraph implements IAgreementConnector {
   }
 
   async version(versionId: string): Promise<Version> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Version>(
       queries.GET_VERSION('query'),
       { versionId },
       (result: QueryResult) => parseVersion(result, this)
     )
   }
 
-  onVersion(versionId: string, callback: Function): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+  onVersion(
+    versionId: string,
+    callback: SubscriptionCallback<Version>
+  ): SubscriptionHandler {
+    return this.#gql.subscribeToQueryWithParser<Version>(
       queries.GET_VERSION('subscription'),
       { versionId },
       callback,
@@ -109,7 +121,7 @@ export default class AgreementConnectorTheGraph implements IAgreementConnector {
     first: number,
     skip: number
   ): Promise<Version[]> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Version[]>(
       queries.ALL_VERSIONS('query'),
       { agreement, first, skip },
       (result: QueryResult) => parseVersions(result, this)
@@ -120,9 +132,9 @@ export default class AgreementConnectorTheGraph implements IAgreementConnector {
     agreement: string,
     first: number,
     skip: number,
-    callback: Function
+    callback: SubscriptionCallback<Version[]>
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<Version[]>(
       queries.ALL_VERSIONS('subscription'),
       { agreement, first, skip },
       callback,
@@ -131,15 +143,18 @@ export default class AgreementConnectorTheGraph implements IAgreementConnector {
   }
 
   async signer(signerId: string): Promise<Signer> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Signer>(
       queries.GET_SIGNER('query'),
       { signerId },
       (result: QueryResult) => parseSigner(result, this)
     )
   }
 
-  onSigner(signerId: string, callback: Function): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+  onSigner(
+    signerId: string,
+    callback: SubscriptionCallback<Signer>
+  ): SubscriptionHandler {
+    return this.#gql.subscribeToQueryWithParser<Signer>(
       queries.GET_SIGNER('query'),
       { signerId },
       callback,
@@ -152,7 +167,7 @@ export default class AgreementConnectorTheGraph implements IAgreementConnector {
     first: number,
     skip: number
   ): Promise<Signature[]> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Signature[]>(
       queries.GET_SIGNATURES('query'),
       { signerId, first, skip },
       (result: QueryResult) => parseSignatures(result, this)
@@ -163,9 +178,9 @@ export default class AgreementConnectorTheGraph implements IAgreementConnector {
     signerId: string,
     first: number,
     skip: number,
-    callback: Function
+    callback: SubscriptionCallback<Signature[]>
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<Signature[]>(
       queries.GET_SIGNATURES('query'),
       { signerId, first, skip },
       callback,

--- a/packages/connect-agreement/src/types.ts
+++ b/packages/connect-agreement/src/types.ts
@@ -1,4 +1,7 @@
-import { SubscriptionHandler } from '@aragon/connect-types'
+import {
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 
 import Signer from './models/Signer'
 import Signature from './models/Signature'
@@ -37,20 +40,32 @@ export interface SignatureData {
 export interface IAgreementConnector {
   disconnect(): Promise<void>
   agreement(agreement: string): Promise<AgreementData>
-  onAgreement(agreement: string, callback: Function): SubscriptionHandler
+  onAgreement(
+    agreement: string,
+    callback: SubscriptionCallback<AgreementData>
+  ): SubscriptionHandler
   currentVersion(agreement: string): Promise<Version>
-  onCurrentVersion(agreement: string, callback: Function): SubscriptionHandler
+  onCurrentVersion(
+    agreement: string,
+    callback: SubscriptionCallback<Version>
+  ): SubscriptionHandler
   version(versionId: string): Promise<Version>
-  onVersion(versionId: string, callback: Function): SubscriptionHandler
+  onVersion(
+    versionId: string,
+    callback: SubscriptionCallback<Version>
+  ): SubscriptionHandler
   versions(agreement: string, first: number, skip: number): Promise<Version[]>
   onVersions(
     agreement: string,
     first: number,
     skip: number,
-    callback: Function
+    callback: SubscriptionCallback<Version[]>
   ): SubscriptionHandler
   signer(signerId: string): Promise<Signer>
-  onSigner(signerId: string, callback: Function): SubscriptionHandler
+  onSigner(
+    signerId: string,
+    callback: SubscriptionCallback<Signer>
+  ): SubscriptionHandler
   signatures(
     signerId: string,
     first: number,
@@ -60,6 +75,6 @@ export interface IAgreementConnector {
     signerId: string,
     first: number,
     skip: number,
-    callback: Function
+    callback: SubscriptionCallback<Signature[]>
   ): SubscriptionHandler
 }

--- a/packages/connect-core/src/connections/ConnectorJson.ts
+++ b/packages/connect-core/src/connections/ConnectorJson.ts
@@ -3,7 +3,13 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
-import { AppFilters, Network, SubscriptionHandler } from '@aragon/connect-types'
+import {
+  Address,
+  AppFilters,
+  Network,
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import { ConnectionContext } from '../types'
 import IOrganizationConnector from './IOrganizationConnector'
 import App from '../entities/App'
@@ -44,7 +50,7 @@ class ConnectorJson implements IOrganizationConnector {
 
   onPermissionsForOrg(
     organization: Organization,
-    callback: Function
+    callback: SubscriptionCallback<Permission[]>
   ): SubscriptionHandler {
     return {
       unsubscribe: () => {},
@@ -65,39 +71,39 @@ class ConnectorJson implements IOrganizationConnector {
     })
   }
 
+  onAppForOrg(
+    organization: Organization,
+    filters: AppFilters,
+    callback: SubscriptionCallback<App>
+  ): SubscriptionHandler {
+    return {
+      unsubscribe: () => {},
+    }
+  }
+
   appsForOrg(organization: Organization): Promise<App[]> {
     return new Promise((resolve) => {
       resolve([])
     })
   }
 
-  onAppForOrg(
-    organization: Organization,
-    filters: AppFilters,
-    callback: Function
-  ): SubscriptionHandler {
-    return {
-      unsubscribe: () => {},
-    }
-  }
-
   onAppsForOrg(
     organization: Organization,
     filters: AppFilters,
-    callback: Function
+    callback: SubscriptionCallback<App[]>
   ): SubscriptionHandler {
     return {
       unsubscribe: () => {},
     }
   }
 
-  repoForApp(organization: Organization, appAddress: string): Promise<Repo> {
+  repoForApp(organization: Organization, appAddress: Address): Promise<Repo> {
     return new Promise((resolve) => {
       resolve()
     })
   }
 
-  appByAddress(organization: Organization, appAddress: string): Promise<App> {
+  appByAddress(organization: Organization, appAddress: Address): Promise<App> {
     return new Promise((resolve) => {
       resolve()
     })
@@ -105,7 +111,7 @@ class ConnectorJson implements IOrganizationConnector {
 
   rolesForAddress(
     organization: Organization,
-    appAddress: string
+    appAddress: Address
   ): Promise<Role[]> {
     return new Promise((resolve) => {
       resolve([])

--- a/packages/connect-core/src/connections/IOrganizationConnector.ts
+++ b/packages/connect-core/src/connections/IOrganizationConnector.ts
@@ -1,4 +1,9 @@
-import { AppFilters, Network, SubscriptionHandler } from '@aragon/connect-types'
+import {
+  AppFilters,
+  Network,
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import { ConnectionContext } from '../types'
 import App from '../entities/App'
 import Organization from '../entities/Organization'
@@ -10,27 +15,34 @@ export default interface IOrganizationConnector {
   readonly name: string
   readonly network: Network
   readonly config: { [key: string]: any }
-  appByAddress(organization: Organization, appAddress: string): Promise<App>
-  appForOrg(organization: Organization, filters?: AppFilters): Promise<App>
-  appsForOrg(organization: Organization, filters?: AppFilters): Promise<App[]>
+
   connect?(connection: ConnectionContext): Promise<void>
   disconnect?(): Promise<void>
+
+  appByAddress(organization: Organization, appAddress: string): Promise<App>
+
+  appForOrg(organization: Organization, filters?: AppFilters): Promise<App>
   onAppForOrg(
     organization: Organization,
     filters: AppFilters,
-    callback: Function
+    callback: SubscriptionCallback<App>
   ): SubscriptionHandler
+
+  appsForOrg(organization: Organization, filters?: AppFilters): Promise<App[]>
   onAppsForOrg(
     organization: Organization,
     filters: AppFilters,
-    callback: Function
+    callback: SubscriptionCallback<App[]>
   ): SubscriptionHandler
+
+  permissionsForOrg(organization: Organization): Promise<Permission[]>
   onPermissionsForOrg(
     organization: Organization,
-    callback: Function
+    callback: SubscriptionCallback<Permission[]>
   ): SubscriptionHandler
-  permissionsForOrg(organization: Organization): Promise<Permission[]>
+
   repoForApp(organization: Organization, appAddress: string): Promise<Repo>
+
   rolesForAddress(
     organization: Organization,
     appAddress: string

--- a/packages/connect-core/src/entities/Organization.ts
+++ b/packages/connect-core/src/entities/Organization.ts
@@ -3,6 +3,7 @@ import {
   AppFilters,
   AppFiltersParam,
   SubscriptionHandler,
+  SubscriptionCallback,
 } from '@aragon/connect-types'
 import { ConnectionContext } from '../types'
 import TransactionIntent from '../transactions/TransactionIntent'
@@ -18,8 +19,8 @@ import Permission from './Permission'
 // Organization#roleManager(appAddress, roleId)
 // Organization#setRoleManager(address, appAddress, roleId)
 
-type OnAppCallback = (app: App) => void
-type OnAppsCallback = (apps: App[]) => void
+type OnAppCallback = SubscriptionCallback<App>
+type OnAppsCallback = SubscriptionCallback<App[]>
 
 function normalizeAppFilters(filters?: AppFiltersParam): AppFilters {
   if (!filters) {
@@ -117,7 +118,9 @@ export default class Organization {
     return this.connection.orgConnector.permissionsForOrg(this)
   }
 
-  onPermissions(callback: Function): SubscriptionHandler {
+  onPermissions(
+    callback: SubscriptionCallback<Permission[]>
+  ): SubscriptionHandler {
     return this.connection.orgConnector.onPermissionsForOrg(this, callback)
   }
 

--- a/packages/connect-ethereum/src/index.ts
+++ b/packages/connect-ethereum/src/index.ts
@@ -3,7 +3,13 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
-import { AppFilters, Network, SubscriptionHandler } from '@aragon/connect-types'
+import {
+  Address,
+  AppFilters,
+  Network,
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import {
   App,
   ConnectionContext,
@@ -45,7 +51,7 @@ class ConnectorEthereum implements IOrganizationConnector {
 
   onPermissionsForOrg(
     organization: Organization,
-    callback: Function
+    callback: SubscriptionCallback<Permission[]>
   ): SubscriptionHandler {
     return {
       unsubscribe: () => {},
@@ -67,7 +73,7 @@ class ConnectorEthereum implements IOrganizationConnector {
   onAppForOrg(
     organization: Organization,
     filters: AppFilters,
-    callback: Function
+    callback: SubscriptionCallback<App>
   ): SubscriptionHandler {
     return {
       unsubscribe: () => {},
@@ -77,20 +83,20 @@ class ConnectorEthereum implements IOrganizationConnector {
   onAppsForOrg(
     organization: Organization,
     filters: AppFilters,
-    callback: Function
+    callback: SubscriptionCallback<App[]>
   ): SubscriptionHandler {
     return {
       unsubscribe: () => {},
     }
   }
 
-  repoForApp(organization: Organization, appAddress: string): Promise<Repo> {
+  repoForApp(organization: Organization, appAddress: Address): Promise<Repo> {
     return new Promise((resolve) => {
       resolve()
     })
   }
 
-  appByAddress(organization: Organization, appAddress: string): Promise<App> {
+  appByAddress(organization: Organization, appAddress: Address): Promise<App> {
     return new Promise((resolve) => {
       resolve()
     })
@@ -98,7 +104,7 @@ class ConnectorEthereum implements IOrganizationConnector {
 
   rolesForAddress(
     organization: Organization,
-    appAddress: string
+    appAddress: Address
   ): Promise<Role[]> {
     return new Promise((resolve) => {
       resolve([])

--- a/packages/connect-finance/src/models/Finance.ts
+++ b/packages/connect-finance/src/models/Finance.ts
@@ -1,4 +1,8 @@
-import { Address, SubscriptionHandler } from '@aragon/connect-types'
+import {
+  Address,
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import { IFinanceConnector } from '../types'
 import Transaction from './Transaction'
 import TokenBalance from './TokenBalance'
@@ -22,7 +26,7 @@ export default class Finance {
 
   onTransactions(
     { first = 1000, skip = 0 } = {},
-    callback: Function
+    callback: SubscriptionCallback<Transaction[]>
   ): SubscriptionHandler {
     return this.#connector.onTransactionsForApp!(
       this.#appAddress,
@@ -47,7 +51,7 @@ export default class Finance {
   onBalance(
     tokenAddress: string,
     { first = 1000, skip = 0 } = {},
-    callback: Function
+    callback: SubscriptionCallback<TokenBalance>
   ): SubscriptionHandler {
     return this.#connector.onBalanceForToken!(
       this.#appAddress,

--- a/packages/connect-finance/src/thegraph/connector.ts
+++ b/packages/connect-finance/src/thegraph/connector.ts
@@ -1,4 +1,8 @@
-import { SubscriptionHandler } from '@aragon/connect-types'
+import {
+  Address,
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import { GraphQLWrapper, QueryResult } from '@aragon/connect-thegraph'
 import { IFinanceConnector } from '../types'
 import Transaction from '../models/Transaction'
@@ -45,11 +49,11 @@ export default class FinanceConnectorTheGraph implements IFinanceConnector {
   }
 
   async transactionsForApp(
-    appAddress: string,
+    appAddress: Address,
     first: number,
     skip: number
   ): Promise<Transaction[]> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Transaction[]>(
       queries.ALL_TRANSACTIONS('query'),
       { appAddress, first, skip },
       (result: QueryResult) => parseTransactions(result)
@@ -57,12 +61,12 @@ export default class FinanceConnectorTheGraph implements IFinanceConnector {
   }
 
   onTransactionsForApp(
-    appAddress: string,
-    callback: Function,
+    appAddress: Address,
+    callback: SubscriptionCallback<Transaction[]>,
     first: number,
     skip: number
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<Transaction[]>(
       queries.ALL_TRANSACTIONS('subscription'),
       { appAddress, first, skip },
       callback,
@@ -71,12 +75,12 @@ export default class FinanceConnectorTheGraph implements IFinanceConnector {
   }
 
   async balanceForToken(
-    appAddress: string,
-    tokenAddress: string,
+    appAddress: Address,
+    tokenAddress: Address,
     first: number,
     skip: number
   ): Promise<TokenBalance> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<TokenBalance>(
       queries.BALANCE_FOR_TOKEN('query'),
       { appAddress, tokenAddress, first, skip },
       (result: QueryResult) => parseTokenBalance(result)
@@ -84,13 +88,13 @@ export default class FinanceConnectorTheGraph implements IFinanceConnector {
   }
 
   onBalanceForToken(
-    appAddress: string,
-    tokenAddress: string,
-    callback: Function,
+    appAddress: Address,
+    tokenAddress: Address,
+    callback: SubscriptionCallback<TokenBalance>,
     first: number,
     skip: number
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<TokenBalance>(
       queries.BALANCE_FOR_TOKEN('subscription'),
       { appAddress, tokenAddress, first, skip },
       callback,

--- a/packages/connect-finance/src/types.ts
+++ b/packages/connect-finance/src/types.ts
@@ -1,4 +1,8 @@
-import { SubscriptionHandler, Address } from '@aragon/connect-types'
+import {
+  Address,
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import Transaction from './models/Transaction'
 import TokenBalance from './models/TokenBalance'
 
@@ -27,7 +31,7 @@ export interface IFinanceConnector {
   ): Promise<Transaction[]>
   onTransactionsForApp(
     appAddress: string,
-    callback: Function,
+    callback: SubscriptionCallback<Transaction[]>,
     first: number,
     skip: number
   ): SubscriptionHandler
@@ -40,7 +44,7 @@ export interface IFinanceConnector {
   onBalanceForToken(
     appAddress: string,
     tokenAddress: string,
-    callback: Function,
+    callback: SubscriptionCallback<TokenBalance>,
     first: number,
     skip: number
   ): SubscriptionHandler

--- a/packages/connect-thegraph/src/connector.ts
+++ b/packages/connect-thegraph/src/connector.ts
@@ -168,10 +168,7 @@ class ConnectorTheGraph implements IOrganizationConnector {
         orgAddress: organization.address.toLowerCase(),
       },
       callback,
-      async (result) => {
-        const apps = await parseApps(result, organization)
-        return apps[0]
-      }
+      (result) => parseApp(result, organization)
     )
   }
 

--- a/packages/connect-thegraph/src/connector.ts
+++ b/packages/connect-thegraph/src/connector.ts
@@ -14,6 +14,7 @@ import {
   Network,
   Networkish,
   SubscriptionHandler,
+  SubscriptionCallback,
 } from '@aragon/connect-types'
 import * as queries from './queries'
 import GraphQLWrapper from './core/GraphQLWrapper'
@@ -117,9 +118,9 @@ class ConnectorTheGraph implements IOrganizationConnector {
 
   onPermissionsForOrg(
     organization: Organization,
-    callback: Function
+    callback: SubscriptionCallback<Permission[]>
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<Permission[]>(
       queries.ORGANIZATION_PERMISSIONS('subscription'),
       { orgAddress: organization.address.toLowerCase() },
       callback,
@@ -154,6 +155,26 @@ class ConnectorTheGraph implements IOrganizationConnector {
     return apps[0]
   }
 
+  onAppForOrg(
+    organization: Organization,
+    filters: AppFilters,
+    callback: SubscriptionCallback<App>
+  ): SubscriptionHandler {
+    return this.#gql.subscribeToQueryWithParser<App>(
+      queries.ORGANIZATION_APPS('subscription'),
+      {
+        appFilter: appFiltersToQueryFilter(filters),
+        first: 1,
+        orgAddress: organization.address.toLowerCase(),
+      },
+      callback,
+      async (result) => {
+        const apps = await parseApps(result, organization)
+        return apps[0]
+      }
+    )
+  }
+
   async appsForOrg(
     organization: Organization,
     filters: AppFilters
@@ -168,27 +189,10 @@ class ConnectorTheGraph implements IOrganizationConnector {
     )
   }
 
-  onAppForOrg(
-    organization: Organization,
-    filters: AppFilters,
-    callback: Function
-  ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser<App[]>(
-      queries.ORGANIZATION_APPS('subscription'),
-      {
-        appFilter: appFiltersToQueryFilter(filters),
-        first: 1,
-        orgAddress: organization.address.toLowerCase(),
-      },
-      (apps: App[]) => callback(apps[0]),
-      (result) => parseApps(result, organization)
-    )
-  }
-
   onAppsForOrg(
     organization: Organization,
     filters: AppFilters,
-    callback: Function
+    callback: SubscriptionCallback<App[]>
   ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser<App[]>(
       queries.ORGANIZATION_APPS('subscription'),
@@ -205,7 +209,7 @@ class ConnectorTheGraph implements IOrganizationConnector {
     organization: Organization,
     appAddress: Address
   ): Promise<Repo> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Repo>(
       queries.REPO_BY_APP_ADDRESS('query'),
       { appAddress: appAddress.toLowerCase() },
       (result) => parseRepo(result, organization)

--- a/packages/connect-tokens/src/models/Tokens.ts
+++ b/packages/connect-tokens/src/models/Tokens.ts
@@ -1,4 +1,8 @@
-import { Address, SubscriptionHandler } from '@aragon/connect-types'
+import {
+  Address,
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import { ITokensConnector } from '../types'
 import Token from './Token'
 import TokenHolder from './TokenHolder'
@@ -25,7 +29,9 @@ export default class Tokens {
     return this.#connector.tokenHolders(token.address, first, skip)
   }
 
-  onHolders(callback: Function): SubscriptionHandler {
+  onHolders(
+    callback: SubscriptionCallback<TokenHolder[]>
+  ): SubscriptionHandler {
     return this.#connector.onTokenHolders(this.#appAddress, callback)
   }
 }

--- a/packages/connect-tokens/src/thegraph/connector.ts
+++ b/packages/connect-tokens/src/thegraph/connector.ts
@@ -1,4 +1,8 @@
-import { Address, SubscriptionHandler } from '@aragon/connect-types'
+import {
+  Address,
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import { GraphQLWrapper } from '@aragon/connect-thegraph'
 import { ITokensConnector } from '../types'
 import * as queries from './queries'
@@ -86,9 +90,9 @@ export default class TokensConnectorTheGraph implements ITokensConnector {
 
   onTokenHolders(
     tokenAddress: string,
-    callback: Function
+    callback: SubscriptionCallback<TokenHolder[]>
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<TokenHolder[]>(
       queries.TOKEN_HOLDERS('subscription'),
       { tokenAddress, first: 1000, skip: 0 },
       callback,

--- a/packages/connect-tokens/src/types.ts
+++ b/packages/connect-tokens/src/types.ts
@@ -1,4 +1,8 @@
-import { SubscriptionHandler, Address } from '@aragon/connect-types'
+import {
+  Address,
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import Token from './models/Token'
 import TokenHolder from './models/TokenHolder'
 
@@ -25,5 +29,8 @@ export interface ITokensConnector {
     first: number,
     skip: number
   ): Promise<TokenHolder[]>
-  onTokenHolders(tokenAddress: string, callback: Function): SubscriptionHandler
+  onTokenHolders(
+    tokenAddress: string,
+    callback: SubscriptionCallback<TokenHolder[]>
+  ): SubscriptionHandler
 }

--- a/packages/connect-types/src/index.ts
+++ b/packages/connect-types/src/index.ts
@@ -30,3 +30,5 @@ export type AppFiltersParam =
     }
 
 export type SubscriptionHandler = { unsubscribe: () => void }
+
+export type SubscriptionCallback<T> = (error: Error | null, data?: T) => void

--- a/packages/connect-voting-disputable/src/models/CastVote.ts
+++ b/packages/connect-voting-disputable/src/models/CastVote.ts
@@ -1,4 +1,7 @@
-import { SubscriptionHandler } from '@aragon/connect-types'
+import {
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 
 import Voter from './Voter'
 import { CastVoteData, IDisputableVotingConnector } from '../types'
@@ -30,7 +33,7 @@ export default class CastVote {
     return this.#connector.voter(this.voterId)
   }
 
-  onVoter(callback: Function): SubscriptionHandler {
+  onVoter(callback: SubscriptionCallback<Voter>): SubscriptionHandler {
     return this.#connector.onVoter(this.voterId, callback)
   }
 }

--- a/packages/connect-voting-disputable/src/models/DisputableVoting.ts
+++ b/packages/connect-voting-disputable/src/models/DisputableVoting.ts
@@ -1,4 +1,8 @@
-import { Address, SubscriptionHandler } from '@aragon/connect-types'
+import {
+  Address,
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 
 import Vote from './Vote'
 import Voter from './Voter'
@@ -41,7 +45,9 @@ export default class DisputableVoting {
     return this.#connector.currentSetting(this.#address)
   }
 
-  onCurrentSetting(callback: Function): SubscriptionHandler {
+  onCurrentSetting(
+    callback: SubscriptionCallback<Setting>
+  ): SubscriptionHandler {
     return this.#connector.onCurrentSetting(this.#address, callback)
   }
 
@@ -49,7 +55,10 @@ export default class DisputableVoting {
     return this.#connector.setting(this.settingId(settingNumber))
   }
 
-  onSetting(settingNumber: string, callback: Function): SubscriptionHandler {
+  onSetting(
+    settingNumber: string,
+    callback: SubscriptionCallback<Setting>
+  ): SubscriptionHandler {
     return this.#connector.onSetting(this.settingId(settingNumber), callback)
   }
 
@@ -57,7 +66,10 @@ export default class DisputableVoting {
     return this.#connector.settings(this.#address, first, skip)
   }
 
-  onSettings({ first = 1000, skip = 0 } = {}, callback: Function): SubscriptionHandler {
+  onSettings(
+    { first = 1000, skip = 0 } = {},
+    callback: SubscriptionCallback<Setting[]>
+  ): SubscriptionHandler {
     return this.#connector.onSettings(this.#address, first, skip, callback)
   }
 
@@ -65,7 +77,10 @@ export default class DisputableVoting {
     return this.#connector.vote(voteId)
   }
 
-  onVote(voteId: string, callback: Function): SubscriptionHandler {
+  onVote(
+    voteId: string,
+    callback: SubscriptionCallback<Vote>
+  ): SubscriptionHandler {
     return this.#connector.onVote(voteId, callback)
   }
 
@@ -73,7 +88,10 @@ export default class DisputableVoting {
     return this.#connector.votes(this.#address, first, skip)
   }
 
-  onVotes({ first = 1000, skip = 0 } = {}, callback: Function): SubscriptionHandler {
+  onVotes(
+    { first = 1000, skip = 0 } = {},
+    callback: SubscriptionCallback<Vote[]>
+  ): SubscriptionHandler {
     return this.#connector.onVotes(this.#address, first, skip, callback)
   }
 
@@ -85,7 +103,10 @@ export default class DisputableVoting {
     return this.#connector.voter(this.voterId(voterAddress))
   }
 
-  onVoter(voterAddress: string, callback: Function): SubscriptionHandler {
+  onVoter(
+    voterAddress: string,
+    callback: SubscriptionCallback<Voter>
+  ): SubscriptionHandler {
     return this.#connector.onVoter(this.voterId(voterAddress), callback)
   }
 }

--- a/packages/connect-voting-disputable/src/models/Vote.ts
+++ b/packages/connect-voting-disputable/src/models/Vote.ts
@@ -1,5 +1,8 @@
 import { BigNumber } from 'ethers'
-import { SubscriptionHandler } from '@aragon/connect-types'
+import {
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 
 import CastVote from './CastVote'
 import CollateralRequirement from './CollateralRequirement'
@@ -53,9 +56,15 @@ export default class Vote {
   }
 
   get endDate(): string {
-    const originalEndDate = BigNumber.from(this.startDate).add(BigNumber.from(this.duration))
-    const endDateAfterPause = originalEndDate.add(BigNumber.from(this.pauseDuration))
-    return endDateAfterPause.add(BigNumber.from(this.quietEndingExtendedSeconds)).toString()
+    const originalEndDate = BigNumber.from(this.startDate).add(
+      BigNumber.from(this.duration)
+    )
+    const endDateAfterPause = originalEndDate.add(
+      BigNumber.from(this.pauseDuration)
+    )
+    return endDateAfterPause
+      .add(BigNumber.from(this.quietEndingExtendedSeconds))
+      .toString()
   }
 
   get yeasPct(): string {
@@ -68,7 +77,10 @@ export default class Vote {
 
   votingPowerPct(num: string): string {
     const votingPower = BigNumber.from(this.votingPower)
-    return BigNumber.from(num).mul(BigNumber.from(100)).div(votingPower).toString()
+    return BigNumber.from(num)
+      .mul(BigNumber.from(100))
+      .div(votingPower)
+      .toString()
   }
 
   castVoteId(voterAddress: string): string {
@@ -79,7 +91,10 @@ export default class Vote {
     return this.#connector.castVote(this.castVoteId(voterAddress))
   }
 
-  onCastVote(voterAddress: string, callback: Function): SubscriptionHandler {
+  onCastVote(
+    voterAddress: string,
+    callback: SubscriptionCallback<CastVote | null>
+  ): SubscriptionHandler {
     return this.#connector.onCastVote(this.castVoteId(voterAddress), callback)
   }
 
@@ -87,7 +102,10 @@ export default class Vote {
     return this.#connector.castVotes(this.id, first, skip)
   }
 
-  onCastVotes({ first = 1000, skip = 0 } = {}, callback: Function): SubscriptionHandler {
+  onCastVotes(
+    { first = 1000, skip = 0 } = {},
+    callback: SubscriptionCallback<CastVote[]>
+  ): SubscriptionHandler {
     return this.#connector.onCastVotes(this.id, first, skip, callback)
   }
 
@@ -95,7 +113,9 @@ export default class Vote {
     return this.#connector.collateralRequirement(this.id)
   }
 
-  onCollateralRequirement(callback: Function): SubscriptionHandler {
+  onCollateralRequirement(
+    callback: SubscriptionCallback<CollateralRequirement>
+  ): SubscriptionHandler {
     return this.#connector.onCollateralRequirement(this.id, callback)
   }
 }

--- a/packages/connect-voting-disputable/src/thegraph/connector.ts
+++ b/packages/connect-voting-disputable/src/thegraph/connector.ts
@@ -1,4 +1,7 @@
-import { SubscriptionHandler } from '@aragon/connect-types'
+import {
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import { GraphQLWrapper, QueryResult } from '@aragon/connect-thegraph'
 
 import { DisputableVotingData, IDisputableVotingConnector } from '../types'
@@ -63,7 +66,7 @@ export default class DisputableVotingConnectorTheGraph
   async disputableVoting(
     disputableVoting: string
   ): Promise<DisputableVotingData> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<DisputableVotingData>(
       queries.GET_DISPUTABLE_VOTING('query'),
       { disputableVoting },
       (result: QueryResult) => parseDisputableVoting(result)
@@ -72,9 +75,9 @@ export default class DisputableVotingConnectorTheGraph
 
   onDisputableVoting(
     disputableVoting: string,
-    callback: Function
+    callback: SubscriptionCallback<DisputableVotingData>
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<DisputableVotingData>(
       queries.GET_DISPUTABLE_VOTING('subscription'),
       { disputableVoting },
       callback,
@@ -83,7 +86,7 @@ export default class DisputableVotingConnectorTheGraph
   }
 
   async currentSetting(disputableVoting: string): Promise<Setting> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Setting>(
       queries.GET_CURRENT_SETTING('query'),
       { disputableVoting },
       (result: QueryResult) => parseCurrentSetting(result, this)
@@ -92,9 +95,9 @@ export default class DisputableVotingConnectorTheGraph
 
   onCurrentSetting(
     disputableVoting: string,
-    callback: Function
+    callback: SubscriptionCallback<Setting>
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<Setting>(
       queries.GET_CURRENT_SETTING('subscription'),
       { disputableVoting },
       callback,
@@ -103,15 +106,18 @@ export default class DisputableVotingConnectorTheGraph
   }
 
   async setting(settingId: string): Promise<Setting> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Setting>(
       queries.GET_SETTING('query'),
       { settingId },
       (result: QueryResult) => parseSetting(result, this)
     )
   }
 
-  onSetting(settingId: string, callback: Function): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+  onSetting(
+    settingId: string,
+    callback: SubscriptionCallback<Setting>
+  ): SubscriptionHandler {
+    return this.#gql.subscribeToQueryWithParser<Setting>(
       queries.GET_SETTING('subscription'),
       { settingId },
       callback,
@@ -124,7 +130,7 @@ export default class DisputableVotingConnectorTheGraph
     first: number,
     skip: number
   ): Promise<Setting[]> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Setting[]>(
       queries.ALL_SETTINGS('query'),
       { disputableVoting, first, skip },
       (result: QueryResult) => parseSettings(result, this)
@@ -135,9 +141,9 @@ export default class DisputableVotingConnectorTheGraph
     disputableVoting: string,
     first: number,
     skip: number,
-    callback: Function
+    callback: SubscriptionCallback<Setting[]>
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<Setting[]>(
       queries.ALL_SETTINGS('subscription'),
       { disputableVoting, first, skip },
       callback,
@@ -146,15 +152,18 @@ export default class DisputableVotingConnectorTheGraph
   }
 
   async vote(voteId: string): Promise<Vote> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Vote>(
       queries.GET_VOTE('query'),
       { voteId },
       (result: QueryResult) => parseVote(result, this)
     )
   }
 
-  onVote(voteId: string, callback: Function): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+  onVote(
+    voteId: string,
+    callback: SubscriptionCallback<Vote>
+  ): SubscriptionHandler {
+    return this.#gql.subscribeToQueryWithParser<Vote>(
       queries.GET_VOTE('subscription'),
       { voteId },
       callback,
@@ -167,7 +176,7 @@ export default class DisputableVotingConnectorTheGraph
     first: number,
     skip: number
   ): Promise<Vote[]> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Vote[]>(
       queries.ALL_VOTES('query'),
       { disputableVoting, first, skip },
       (result: QueryResult) => parseVotes(result, this)
@@ -178,9 +187,9 @@ export default class DisputableVotingConnectorTheGraph
     disputableVoting: string,
     first: number,
     skip: number,
-    callback: Function
+    callback: SubscriptionCallback<Vote[]>
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<Vote[]>(
       queries.ALL_VOTES('subscription'),
       { disputableVoting, first, skip },
       callback,
@@ -189,15 +198,18 @@ export default class DisputableVotingConnectorTheGraph
   }
 
   async castVote(castVoteId: string): Promise<CastVote | null> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<CastVote | null>(
       queries.GET_CAST_VOTE('query'),
       { castVoteId },
       (result: QueryResult) => parseCastVote(result, this)
     )
   }
 
-  onCastVote(castVoteId: string, callback: Function): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+  onCastVote(
+    castVoteId: string,
+    callback: SubscriptionCallback<CastVote | null>
+  ): SubscriptionHandler {
+    return this.#gql.subscribeToQueryWithParser<CastVote | null>(
       queries.GET_CAST_VOTE('subscription'),
       { castVoteId },
       callback,
@@ -210,7 +222,7 @@ export default class DisputableVotingConnectorTheGraph
     first: number,
     skip: number
   ): Promise<CastVote[]> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<CastVote[]>(
       queries.ALL_CAST_VOTES('query'),
       { voteId, first, skip },
       (result: QueryResult) => parseCastVotes(result, this)
@@ -221,9 +233,9 @@ export default class DisputableVotingConnectorTheGraph
     voteId: string,
     first: number,
     skip: number,
-    callback: Function
+    callback: SubscriptionCallback<CastVote[]>
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<CastVote[]>(
       queries.ALL_CAST_VOTES('subscription'),
       { voteId, first, skip },
       callback,
@@ -232,15 +244,18 @@ export default class DisputableVotingConnectorTheGraph
   }
 
   async voter(voterId: string): Promise<Voter> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Voter>(
       queries.GET_VOTER('query'),
       { voterId },
       (result: QueryResult) => parseVoter(result, this)
     )
   }
 
-  onVoter(voterId: string, callback: Function): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+  onVoter(
+    voterId: string,
+    callback: SubscriptionCallback<Voter>
+  ): SubscriptionHandler {
+    return this.#gql.subscribeToQueryWithParser<Voter>(
       queries.GET_VOTER('subscription'),
       { voterId },
       callback,
@@ -249,7 +264,7 @@ export default class DisputableVotingConnectorTheGraph
   }
 
   async collateralRequirement(voteId: string): Promise<CollateralRequirement> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<CollateralRequirement>(
       queries.GET_COLLATERAL_REQUIREMENT('query'),
       { voteId },
       (result: QueryResult) => parseCollateralRequirement(result, this)
@@ -258,9 +273,9 @@ export default class DisputableVotingConnectorTheGraph
 
   onCollateralRequirement(
     voteId: string,
-    callback: Function
+    callback: SubscriptionCallback<CollateralRequirement>
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<CollateralRequirement>(
       queries.GET_COLLATERAL_REQUIREMENT('subscription'),
       { voteId },
       callback,

--- a/packages/connect-voting-disputable/src/types.ts
+++ b/packages/connect-voting-disputable/src/types.ts
@@ -1,4 +1,7 @@
-import { SubscriptionHandler } from '@aragon/connect-types'
+import {
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 
 import Vote from './models/Vote'
 import Voter from './models/Voter'
@@ -77,23 +80,63 @@ export interface CollateralRequirementData {
 export interface IDisputableVotingConnector {
   disconnect(): Promise<void>
   disputableVoting(disputableVoting: string): Promise<DisputableVotingData>
-  onDisputableVoting(disputableVoting: string, callback: Function): SubscriptionHandler
+  onDisputableVoting(
+    disputableVoting: string,
+    callback: SubscriptionCallback<DisputableVotingData>
+  ): SubscriptionHandler
   currentSetting(disputableVoting: string): Promise<Setting>
-  onCurrentSetting(disputableVoting: string, callback: Function): SubscriptionHandler
+  onCurrentSetting(
+    disputableVoting: string,
+    callback: SubscriptionCallback<Setting>
+  ): SubscriptionHandler
   setting(settingId: string): Promise<Setting>
-  onSetting(settingId: string, callback: Function): SubscriptionHandler
-  settings(disputableVoting: string, first: number, skip: number): Promise<Setting[]>
-  onSettings(disputableVoting: string, first: number, skip: number, callback: Function): SubscriptionHandler
+  onSetting(
+    settingId: string,
+    callback: SubscriptionCallback<Setting>
+  ): SubscriptionHandler
+  settings(
+    disputableVoting: string,
+    first: number,
+    skip: number
+  ): Promise<Setting[]>
+  onSettings(
+    disputableVoting: string,
+    first: number,
+    skip: number,
+    callback: SubscriptionCallback<Setting[]>
+  ): SubscriptionHandler
   vote(voteId: string): Promise<Vote>
-  onVote(voteId: string, callback: Function): SubscriptionHandler
+  onVote(
+    voteId: string,
+    callback: SubscriptionCallback<Vote>
+  ): SubscriptionHandler
   votes(disputableVoting: string, first: number, skip: number): Promise<Vote[]>
-  onVotes(disputableVoting: string, first: number, skip: number, callback: Function): SubscriptionHandler
+  onVotes(
+    disputableVoting: string,
+    first: number,
+    skip: number,
+    callback: SubscriptionCallback<Vote[]>
+  ): SubscriptionHandler
   castVote(castVoteId: string): Promise<CastVote | null>
-  onCastVote(castVoteId: string, callback: Function): SubscriptionHandler
+  onCastVote(
+    castVoteId: string,
+    callback: SubscriptionCallback<CastVote | null>
+  ): SubscriptionHandler
   castVotes(voteId: string, first: number, skip: number): Promise<CastVote[]>
-  onCastVotes(voteId: string, first: number, skip: number, callback: Function): SubscriptionHandler
+  onCastVotes(
+    voteId: string,
+    first: number,
+    skip: number,
+    callback: SubscriptionCallback<CastVote[]>
+  ): SubscriptionHandler
   voter(voterId: string): Promise<Voter>
-  onVoter(voterId: string, callback: Function): SubscriptionHandler
+  onVoter(
+    voterId: string,
+    callback: SubscriptionCallback<Voter>
+  ): SubscriptionHandler
   collateralRequirement(voteId: string): Promise<CollateralRequirement>
-  onCollateralRequirement(voteId: string, callback: Function): SubscriptionHandler
+  onCollateralRequirement(
+    voteId: string,
+    callback: SubscriptionCallback<CollateralRequirement>
+  ): SubscriptionHandler
 }

--- a/packages/connect-voting/src/models/Vote.ts
+++ b/packages/connect-voting/src/models/Vote.ts
@@ -1,4 +1,7 @@
-import { SubscriptionHandler } from '@aragon/connect-types'
+import {
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import { IVotingConnector, VoteData } from '../types'
 import Cast from './Cast'
 
@@ -39,7 +42,7 @@ export default class Vote {
     return this.#connector.castsForVote(this.id, first, skip)
   }
 
-  onCasts(callback: Function): SubscriptionHandler {
+  onCasts(callback: SubscriptionCallback<Cast[]>): SubscriptionHandler {
     return this.#connector.onCastsForVote(this.id, callback)
   }
 }

--- a/packages/connect-voting/src/models/Voting.ts
+++ b/packages/connect-voting/src/models/Voting.ts
@@ -1,4 +1,8 @@
-import { Address, SubscriptionHandler } from '@aragon/connect-types'
+import {
+  Address,
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import { IVotingConnector } from '../types'
 import Vote from './Vote'
 
@@ -21,7 +25,7 @@ export default class Voting {
 
   onVotes(
     { first = 1000, skip = 0 } = {},
-    callback: Function
+    callback: SubscriptionCallback<Vote[]>
   ): SubscriptionHandler {
     return this.#connector.onVotesForApp(
       this.#appAddress,

--- a/packages/connect-voting/src/thegraph/connector.ts
+++ b/packages/connect-voting/src/thegraph/connector.ts
@@ -1,4 +1,7 @@
-import { SubscriptionHandler } from '@aragon/connect-types'
+import {
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import { GraphQLWrapper, QueryResult } from '@aragon/connect-thegraph'
 import { IVotingConnector } from '../types'
 import Vote from '../models/Vote'
@@ -49,7 +52,7 @@ export default class VotingConnectorTheGraph implements IVotingConnector {
     first: number,
     skip: number
   ): Promise<Vote[]> {
-    return this.#gql.performQueryWithParser(
+    return this.#gql.performQueryWithParser<Vote[]>(
       queries.ALL_VOTES('query'),
       { appAddress, first, skip },
       (result: QueryResult) => parseVotes(result, this)
@@ -58,11 +61,11 @@ export default class VotingConnectorTheGraph implements IVotingConnector {
 
   onVotesForApp(
     appAddress: string,
-    callback: Function,
+    callback: SubscriptionCallback<Vote[]>,
     first: number,
     skip: number
   ): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+    return this.#gql.subscribeToQueryWithParser<Vote[]>(
       queries.ALL_VOTES('subscription'),
       { appAddress, first, skip },
       callback,
@@ -82,8 +85,11 @@ export default class VotingConnectorTheGraph implements IVotingConnector {
     )
   }
 
-  onCastsForVote(voteId: string, callback: Function): SubscriptionHandler {
-    return this.#gql.subscribeToQueryWithParser(
+  onCastsForVote(
+    voteId: string,
+    callback: SubscriptionCallback<Cast[]>
+  ): SubscriptionHandler {
+    return this.#gql.subscribeToQueryWithParser<Cast[]>(
       queries.CASTS_FOR_VOTE('subscription'),
       { voteId, first: 1000, skip: 0 },
       callback,

--- a/packages/connect-voting/src/types.ts
+++ b/packages/connect-voting/src/types.ts
@@ -1,4 +1,7 @@
-import { SubscriptionHandler } from '@aragon/connect-types'
+import {
+  SubscriptionCallback,
+  SubscriptionHandler,
+} from '@aragon/connect-types'
 import Vote from './models/Vote'
 import Cast from './models/Cast'
 
@@ -29,10 +32,13 @@ export interface IVotingConnector {
   votesForApp(appAddress: string, first: number, skip: number): Promise<Vote[]>
   onVotesForApp(
     appAddress: string,
-    callback: Function,
+    callback: SubscriptionCallback<Vote[]>,
     first: number,
     skip: number
   ): SubscriptionHandler
   castsForVote(voteId: string, first: number, skip: number): Promise<Cast[]>
-  onCastsForVote(voteId: string, callback: Function): SubscriptionHandler
+  onCastsForVote(
+    voteId: string,
+    callback: SubscriptionCallback<Cast[]>
+  ): SubscriptionHandler
 }


### PR DESCRIPTION
This is a breaking change for app connectors and consumers (with the exception of `@aragon/connect-react`). It is necessary to pass errors with subscriptions, the same way we do it for the async functions by throwing errors.

A compatible solution could be to pass the error as a second parameter, but many people are used to Node-style callbacks, so I think it would be too weird to invert the parameters.

Contains the following changes:

- Add the `SubscriptionCallback` type.
- Add types to all the subscriptions methods.
- Move all the subscription methods to use node-style callbacks.
- Update documentation and examples.