### PR TITLE
App connectors: align subscription methods

### DIFF
--- a/packages/connect-finance/src/models/Finance.ts
+++ b/packages/connect-finance/src/models/Finance.ts
@@ -30,9 +30,9 @@ export default class Finance {
   ): SubscriptionHandler {
     return this.#connector.onTransactionsForApp!(
       this.#appAddress,
-      callback,
       first,
-      skip
+      skip,
+      callback
     )
   }
 
@@ -56,9 +56,9 @@ export default class Finance {
     return this.#connector.onBalanceForToken!(
       this.#appAddress,
       tokenAddress,
-      callback,
       first,
-      skip
+      skip,
+      callback
     )
   }
 }

--- a/packages/connect-finance/src/thegraph/connector.ts
+++ b/packages/connect-finance/src/thegraph/connector.ts
@@ -62,9 +62,9 @@ export default class FinanceConnectorTheGraph implements IFinanceConnector {
 
   onTransactionsForApp(
     appAddress: Address,
-    callback: SubscriptionCallback<Transaction[]>,
     first: number,
-    skip: number
+    skip: number,
+    callback: SubscriptionCallback<Transaction[]>
   ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser<Transaction[]>(
       queries.ALL_TRANSACTIONS('subscription'),
@@ -90,9 +90,9 @@ export default class FinanceConnectorTheGraph implements IFinanceConnector {
   onBalanceForToken(
     appAddress: Address,
     tokenAddress: Address,
-    callback: SubscriptionCallback<TokenBalance>,
     first: number,
-    skip: number
+    skip: number,
+    callback: SubscriptionCallback<TokenBalance>
   ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser<TokenBalance>(
       queries.BALANCE_FOR_TOKEN('subscription'),

--- a/packages/connect-finance/src/types.ts
+++ b/packages/connect-finance/src/types.ts
@@ -31,9 +31,9 @@ export interface IFinanceConnector {
   ): Promise<Transaction[]>
   onTransactionsForApp(
     appAddress: string,
-    callback: SubscriptionCallback<Transaction[]>,
     first: number,
-    skip: number
+    skip: number,
+    callback: SubscriptionCallback<Transaction[]>
   ): SubscriptionHandler
   balanceForToken(
     appAddress: string,
@@ -44,8 +44,8 @@ export interface IFinanceConnector {
   onBalanceForToken(
     appAddress: string,
     tokenAddress: string,
-    callback: SubscriptionCallback<TokenBalance>,
     first: number,
-    skip: number
+    skip: number,
+    callback: SubscriptionCallback<TokenBalance>
   ): SubscriptionHandler
 }

--- a/packages/connect-tokens/src/connect.ts
+++ b/packages/connect-tokens/src/connect.ts
@@ -33,6 +33,6 @@ export default createAppConnector<Tokens, Config>(
       verbose,
     })
 
-    return new Tokens(connectorTheGraph, app.address)
+    return Tokens.create(connectorTheGraph)
   }
 )

--- a/packages/connect-tokens/src/models/Tokens.ts
+++ b/packages/connect-tokens/src/models/Tokens.ts
@@ -8,12 +8,17 @@ import Token from './Token'
 import TokenHolder from './TokenHolder'
 
 export default class Tokens {
-  #appAddress: Address
   #connector: ITokensConnector
+  #tokenAddress: Address
 
-  constructor(connector: ITokensConnector, appAddress: Address) {
-    this.#appAddress = appAddress
+  constructor(connector: ITokensConnector, tokenAddress: Address) {
     this.#connector = connector
+    this.#tokenAddress = tokenAddress
+  }
+
+  static async create(connector: ITokensConnector) {
+    const token = await connector.token()
+    return new Tokens(connector, token.address)
   }
 
   async disconnect() {
@@ -25,13 +30,18 @@ export default class Tokens {
   }
 
   async holders({ first = 1000, skip = 0 } = {}): Promise<TokenHolder[]> {
-    const token = await this.token()
-    return this.#connector.tokenHolders(token.address, first, skip)
+    return this.#connector.tokenHolders(this.#tokenAddress, first, skip)
   }
 
   onHolders(
+    { first = 1000, skip = 0 } = {},
     callback: SubscriptionCallback<TokenHolder[]>
   ): SubscriptionHandler {
-    return this.#connector.onTokenHolders(this.#appAddress, callback)
+    return this.#connector.onTokenHolders(
+      this.#tokenAddress,
+      first,
+      skip,
+      callback
+    )
   }
 }

--- a/packages/connect-tokens/src/thegraph/connector.ts
+++ b/packages/connect-tokens/src/thegraph/connector.ts
@@ -90,11 +90,13 @@ export default class TokensConnectorTheGraph implements ITokensConnector {
 
   onTokenHolders(
     tokenAddress: string,
+    first: number,
+    skip: number,
     callback: SubscriptionCallback<TokenHolder[]>
   ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser<TokenHolder[]>(
       queries.TOKEN_HOLDERS('subscription'),
-      { tokenAddress, first: 1000, skip: 0 },
+      { tokenAddress, first, skip },
       callback,
       (result) => parseTokenHolders(result)
     )

--- a/packages/connect-tokens/src/types.ts
+++ b/packages/connect-tokens/src/types.ts
@@ -31,6 +31,8 @@ export interface ITokensConnector {
   ): Promise<TokenHolder[]>
   onTokenHolders(
     tokenAddress: string,
+    first: number,
+    skip: number,
     callback: SubscriptionCallback<TokenHolder[]>
   ): SubscriptionHandler
 }

--- a/packages/connect-voting/src/models/Vote.ts
+++ b/packages/connect-voting/src/models/Vote.ts
@@ -42,7 +42,10 @@ export default class Vote {
     return this.#connector.castsForVote(this.id, first, skip)
   }
 
-  onCasts(callback: SubscriptionCallback<Cast[]>): SubscriptionHandler {
-    return this.#connector.onCastsForVote(this.id, callback)
+  onCasts(
+    { first = 1000, skip = 0 } = {},
+    callback: SubscriptionCallback<Cast[]>
+  ): SubscriptionHandler {
+    return this.#connector.onCastsForVote(this.id, first, skip, callback)
   }
 }

--- a/packages/connect-voting/src/models/Voting.ts
+++ b/packages/connect-voting/src/models/Voting.ts
@@ -29,9 +29,9 @@ export default class Voting {
   ): SubscriptionHandler {
     return this.#connector.onVotesForApp(
       this.#appAddress,
-      callback,
       first,
-      skip
+      skip,
+      callback
     )
   }
 }

--- a/packages/connect-voting/src/thegraph/connector.ts
+++ b/packages/connect-voting/src/thegraph/connector.ts
@@ -61,9 +61,9 @@ export default class VotingConnectorTheGraph implements IVotingConnector {
 
   onVotesForApp(
     appAddress: string,
-    callback: SubscriptionCallback<Vote[]>,
     first: number,
-    skip: number
+    skip: number,
+    callback: SubscriptionCallback<Vote[]>
   ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser<Vote[]>(
       queries.ALL_VOTES('subscription'),

--- a/packages/connect-voting/src/thegraph/connector.ts
+++ b/packages/connect-voting/src/thegraph/connector.ts
@@ -87,11 +87,13 @@ export default class VotingConnectorTheGraph implements IVotingConnector {
 
   onCastsForVote(
     voteId: string,
+    first: number,
+    skip: number,
     callback: SubscriptionCallback<Cast[]>
   ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser<Cast[]>(
       queries.CASTS_FOR_VOTE('subscription'),
-      { voteId, first: 1000, skip: 0 },
+      { voteId, first, skip },
       callback,
       (result: QueryResult) => parseCasts(result)
     )

--- a/packages/connect-voting/src/types.ts
+++ b/packages/connect-voting/src/types.ts
@@ -39,6 +39,8 @@ export interface IVotingConnector {
   castsForVote(voteId: string, first: number, skip: number): Promise<Cast[]>
   onCastsForVote(
     voteId: string,
+    first: number,
+    skip: number,
     callback: SubscriptionCallback<Cast[]>
   ): SubscriptionHandler
 }

--- a/packages/connect-voting/src/types.ts
+++ b/packages/connect-voting/src/types.ts
@@ -32,9 +32,9 @@ export interface IVotingConnector {
   votesForApp(appAddress: string, first: number, skip: number): Promise<Vote[]>
   onVotesForApp(
     appAddress: string,
-    callback: SubscriptionCallback<Vote[]>,
     first: number,
-    skip: number
+    skip: number,
+    callback: SubscriptionCallback<Vote[]>
   ): SubscriptionHandler
   castsForVote(voteId: string, first: number, skip: number): Promise<Cast[]>
   onCastsForVote(


### PR DESCRIPTION
This PR aligns the subscription methods with their async counterparts for the Finance, Voting and Tokens app connectors.

It is a breaking change.