### PR TITLE
Core: prefer generating signature from ABI

### DIFF
--- a/examples/bundler-parcel/package.json
+++ b/examples/bundler-parcel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bundler-parcel",
   "private": true,
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
@@ -9,7 +9,7 @@
     "build": "parcel build src/index.html"
   },
   "dependencies": {
-    "@aragon/connect-react": "^0.8.0-alpha.5",
+    "@aragon/connect-react": "^0.8.0-alpha.6",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "string.ify": "^1.0.64"

--- a/examples/bundler-webpack-ts-loader/package.json
+++ b/examples/bundler-webpack-ts-loader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bundler-webpack-ts-loader",
   "main": "dist/index.js",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "private": true,
   "sideEffects": false,
   "scripts": {
@@ -10,7 +10,7 @@
     "clean": "rm -rf ./dist ./tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@aragon/connect": "^0.8.0-alpha.5",
+    "@aragon/connect": "^0.8.0-alpha.6",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/examples/connect-react-intro/package.json
+++ b/examples/connect-react-intro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-react-intro",
   "private": true,
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "scripts": {
     "start": "snowpack dev",
     "build": "snowpack build"

--- a/examples/list-balances-cli/package.json
+++ b/examples/list-balances-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "list-balances-cli",
   "private": true,
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
@@ -13,8 +13,8 @@
     "typescript": "^3.9.6"
   },
   "dependencies": {
-    "@aragon/connect": "^0.8.0-alpha.5",
-    "@aragon/connect-voting": "^0.8.0-alpha.5",
+    "@aragon/connect": "^0.8.0-alpha.6",
+    "@aragon/connect-voting": "^0.8.0-alpha.6",
     "token-amount": "^0.1.0"
   }
 }

--- a/examples/list-votes-cli/package.json
+++ b/examples/list-votes-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "list-votes-cli",
   "private": true,
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
@@ -13,7 +13,7 @@
     "typescript": "^3.9.6"
   },
   "dependencies": {
-    "@aragon/connect": "^0.8.0-alpha.5",
-    "@aragon/connect-voting": "^0.8.0-alpha.5"
+    "@aragon/connect": "^0.8.0-alpha.6",
+    "@aragon/connect-voting": "^0.8.0-alpha.6"
   }
 }

--- a/examples/list-votes-react/package.json
+++ b/examples/list-votes-react/package.json
@@ -1,14 +1,14 @@
 {
   "name": "list-votes-react",
   "private": true,
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "scripts": {
     "start": "snowpack dev",
     "build": "snowpack build"
   },
   "dependencies": {
-    "@aragon/connect-react": "^0.8.0-alpha.5",
-    "@aragon/connect-voting": "^0.8.0-alpha.5",
+    "@aragon/connect-react": "^0.8.0-alpha.6",
+    "@aragon/connect-voting": "^0.8.0-alpha.6",
     "@emotion/core": "^10.0.28",
     "ethers": "^5.0.7",
     "react": "^16.13.1",

--- a/examples/minimal-setup-web/package.json
+++ b/examples/minimal-setup-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minimal-setup-web",
   "private": true,
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
@@ -9,7 +9,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@aragon/connect-react": "^0.8.0-alpha.5",
+    "@aragon/connect-react": "^0.8.0-alpha.6",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodejs",
   "main": "dist/index.js",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "private": true,
   "scripts": {
     "build": "yarn clean && yarn compile",
@@ -22,10 +22,10 @@
     "start-create-karma-template": "yarn build; node dist/src/create-karma-template.js"
   },
   "dependencies": {
-    "@aragon/connect": "^0.8.0-alpha.5",
-    "@aragon/connect-thegraph": "^0.8.0-alpha.5",
-    "@aragon/connect-tokens": "^0.8.0-alpha.5",
-    "@aragon/connect-voting": "^0.8.0-alpha.5",
+    "@aragon/connect": "^0.8.0-alpha.6",
+    "@aragon/connect-thegraph": "^0.8.0-alpha.6",
+    "@aragon/connect-tokens": "^0.8.0-alpha.6",
+    "@aragon/connect-voting": "^0.8.0-alpha.6",
     "ethers": "^5.0.0",
     "graphql-tag": "^2.10.3"
   },

--- a/examples/org-viewer-react/package.json
+++ b/examples/org-viewer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org-viewer-react",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "private": true,
   "scripts": {
     "start": "yarn clean && webpack-dev-server",
@@ -9,7 +9,7 @@
     "clean": "rm -rf ./dist ./tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@aragon/connect-react": "^0.8.0-alpha.5",
+    "@aragon/connect-react": "^0.8.0-alpha.6",
     "@emotion/core": "^10.0.28",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/examples/org-viewer-web/package.json
+++ b/examples/org-viewer-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org-viewer-web",
   "main": "dist/index.js",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "private": true,
   "sideEffects": false,
   "scripts": {
@@ -12,7 +12,7 @@
     "compile": "tsc"
   },
   "dependencies": {
-    "@aragon/connect": "^0.8.0-alpha.5",
+    "@aragon/connect": "^0.8.0-alpha.6",
     "@emotion/core": "^10.0.28",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/connect",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "description": "Access and interact with Aragon Organizations and their apps.",
   "keywords": [
     "ethereum",

--- a/packages/connect-agreement/package.json
+++ b/packages/connect-agreement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/connect-agreement",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "private": true,
   "license": "LGPL-3.0-or-later",
   "description": "Access and interact with Aragon Organizations and their apps.",
@@ -36,8 +36,8 @@
     "lint": "eslint --ext .ts ./src"
   },
   "dependencies": {
-    "@aragon/connect-core": "^0.8.0-alpha.5",
-    "@aragon/connect-thegraph": "^0.8.0-alpha.5",
+    "@aragon/connect-core": "^0.8.0-alpha.6",
+    "@aragon/connect-thegraph": "^0.8.0-alpha.6",
     "graphql-tag": "^2.10.3"
   },
   "devDependencies": {

--- a/packages/connect-core/package.json
+++ b/packages/connect-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/connect-core",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "license": "LGPL-3.0-or-later",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/connect-core/src/utils/app.ts
+++ b/packages/connect-core/src/utils/app.ts
@@ -73,11 +73,11 @@ export function findAppMethodFromData(
   data: string,
   { allowDeprecated = true } = {}
 ): AppMethod | undefined {
-  const methodId = data.substring(2, 10)
+  const methodId = data.substring(0, 10)
   return findAppMethod(
     app,
     (method: AppMethod) =>
-      ethersUtils.id(method.sig).substring(2, 10) === methodId,
+      ethersUtils.id(method.sig).substring(0, 10) === methodId,
     { allowDeprecated }
   )
 }

--- a/packages/connect-core/src/utils/intent.ts
+++ b/packages/connect-core/src/utils/intent.ts
@@ -20,9 +20,9 @@ export async function appIntent(
   installedApps: App[],
   provider: ethersProvider.Provider
 ): Promise<ForwardingPath> {
-  const acl = installedApps.find((app) => app.name === 'acl')!
+  const acl = installedApps.find((app) => app.name === 'acl')
 
-  if (addressesEqual(destinationApp.address, acl.address)) {
+  if (acl && addressesEqual(destinationApp.address, acl.address)) {
     try {
       return getACLForwardingPath(
         sender,
@@ -60,12 +60,16 @@ export function filterAndDecodeAppUpgradeIntents(
   intents: StepDecoded[],
   installedApps: App[]
 ): ethersUtils.Result[] {
-  const kernelApp = installedApps.find((app) => app.name === 'kernel')!
+  const kernel = installedApps.find((app) => app.name === 'kernel')
+
+  if (!kernel) {
+    throw new Error(`Organization not found.`)
+  }
 
   return (
     intents
       // Filter for setApp() calls to the kernel
-      .filter((intent) => isKernelSetAppIntent(kernelApp, intent))
+      .filter((intent) => isKernelSetAppIntent(kernel, intent))
       // Try to decode setApp() params
       .map((intent) => {
         try {

--- a/packages/connect-disputable-voting/package.json
+++ b/packages/connect-disputable-voting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/connect-disputable-voting",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "private": true,
   "license": "LGPL-3.0-or-later",
   "description": "Access and interact with Aragon Organizations and their apps.",
@@ -36,8 +36,8 @@
     "lint": "eslint --ext .ts ./src"
   },
   "dependencies": {
-    "@aragon/connect-core": "^0.8.0-alpha.5",
-    "@aragon/connect-thegraph": "^0.8.0-alpha.5",
+    "@aragon/connect-core": "^0.8.0-alpha.6",
+    "@aragon/connect-thegraph": "^0.8.0-alpha.6",
     "graphql-tag": "^2.10.3"
   },
   "devDependencies": {

--- a/packages/connect-ethereum/package.json
+++ b/packages/connect-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/connect-ethereum",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "license": "LGPL-3.0-or-later",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -34,7 +34,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@aragon/connect-core": "^0.8.0-alpha.5"
+    "@aragon/connect-core": "^0.8.0-alpha.6"
   },
   "description": "Access and interact with Aragon Organizations and their apps.",
   "keywords": [

--- a/packages/connect-finance/package.json
+++ b/packages/connect-finance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/connect-finance",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "license": "LGPL-3.0-or-later",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -34,8 +34,8 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@aragon/connect-core": "^0.8.0-alpha.5",
-    "@aragon/connect-thegraph": "^0.8.0-alpha.5",
+    "@aragon/connect-core": "^0.8.0-alpha.6",
+    "@aragon/connect-thegraph": "^0.8.0-alpha.6",
     "graphql-tag": "^2.10.3"
   },
   "description": "Access and interact with Aragon Organizations and their apps.",

--- a/packages/connect-react/package.json
+++ b/packages/connect-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/connect-react",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "license": "LGPL-3.0-or-later",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -35,7 +35,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@aragon/connect": "^0.8.0-alpha.5"
+    "@aragon/connect": "^0.8.0-alpha.6"
   },
   "peerDependencies": {
     "react": "^16.13.1"

--- a/packages/connect-thegraph/package.json
+++ b/packages/connect-thegraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/connect-thegraph",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "license": "LGPL-3.0-or-later",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -35,7 +35,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@aragon/connect-core": "^0.8.0-alpha.5",
+    "@aragon/connect-core": "^0.8.0-alpha.6",
     "@urql/core": "^1.11.7",
     "graphql": "^15.0.0",
     "graphql-tag": "^2.10.3",

--- a/packages/connect-tokens/package.json
+++ b/packages/connect-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/connect-tokens",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "license": "LGPL-3.0-or-later",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -34,8 +34,8 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@aragon/connect-core": "^0.8.0-alpha.5",
-    "@aragon/connect-thegraph": "^0.8.0-alpha.5",
+    "@aragon/connect-core": "^0.8.0-alpha.6",
+    "@aragon/connect-thegraph": "^0.8.0-alpha.6",
     "graphql-tag": "^2.10.3"
   },
   "description": "Access and interact with Aragon Organizations and their apps.",

--- a/packages/connect-types/package.json
+++ b/packages/connect-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/connect-types",
   "private": true,
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "license": "LGPL-3.0-or-later",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/connect-voting/package.json
+++ b/packages/connect-voting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/connect-voting",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "license": "LGPL-3.0-or-later",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -34,8 +34,8 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@aragon/connect-core": "^0.8.0-alpha.5",
-    "@aragon/connect-thegraph": "^0.8.0-alpha.5",
+    "@aragon/connect-core": "^0.8.0-alpha.6",
+    "@aragon/connect-thegraph": "^0.8.0-alpha.6",
     "graphql-tag": "^2.10.3"
   },
   "description": "Access and interact with Aragon Organizations and their apps.",

--- a/packages/connect-voting/subgraph/manifest/data/mainnet-staging.json
+++ b/packages/connect-voting/subgraph/manifest/data/mainnet-staging.json
@@ -3,9 +3,9 @@
   "dataSources": {
     "Organizations": [
       {
-        "name": "PieDAO",
-        "address": "0x0c188B183FF758500D1D18B432313d10e9F6b8a4",
-        "startBlock": "9593674"
+        "name": "decentraland",
+        "address": "0xf47917b108ca4b820ccea2587546fbb9f7564b56",
+        "startBlock": "9351139"
       }
     ],
     "OrganizationFactories": [],
@@ -15,4 +15,3 @@
     "Tokens": []
   }
 }
-

--- a/packages/connect-voting/subgraph/manifest/data/rinkeby-staging.json
+++ b/packages/connect-voting/subgraph/manifest/data/rinkeby-staging.json
@@ -3,9 +3,9 @@
   "dataSources": {
     "Organizations": [
       {
-        "name": "SomeOrg",
-        "address": "0x059bCFBC477C46AB39D76c05B7b40f3A42e7DE3B",
-        "startBlock": "6430210"
+        "name": "Decentraland",
+        "address": "0x1dcD3B94027ec9125C475E9c2e09C7B6fAFaD631",
+        "startBlock": "5867546"
       }
     ],
     "OrganizationFactories": [],

--- a/packages/connect-voting/subgraph/schema.graphql
+++ b/packages/connect-voting/subgraph/schema.graphql
@@ -5,6 +5,7 @@ type Vote @entity {
   creator: Bytes!
   metadata: String!
   executed: Boolean!
+  executedAt: BigInt!
   startDate: BigInt!
   snapshotBlock: BigInt!
   supportRequiredPct: BigInt!
@@ -14,17 +15,22 @@ type Vote @entity {
   votingPower: BigInt!
   script: Bytes!
   voteNum: BigInt!
-  casts: [Cast!]!
+  castVotes: [Cast!] @derivedFrom(field: "vote")
 }
 
 type Cast @entity {
   id: ID!
-  voteId: ID!
-  voteNum: BigInt!
-  voter: Bytes!
+  vote: Vote!
+  voter: Voter!
   supports: Boolean!
-  voterStake: BigInt!
-  vote: Vote! @derivedFrom(field: "casts")
+  stake: BigInt!
+  createdAt: BigInt!
+}
+
+type Voter @entity {
+  id: ID!
+  address: Bytes!
+  castVotes: [Cast!] @derivedFrom(field: "voter")
 }
 
 type AragonInfo @entity {

--- a/packages/connect-voting/subgraph/src/Voting.ts
+++ b/packages/connect-voting/subgraph/src/Voting.ts
@@ -3,84 +3,26 @@ import {
   StartVote as StartVoteEvent,
   CastVote as CastVoteEvent,
   ExecuteVote as ExecuteVoteEvent,
-  Voting as VotingContract
+  Voting as VotingContract,
 } from '../generated/templates/Voting/Voting'
 import {
   Vote as VoteEntity,
-  Cast as CastEntity
+  Cast as CastEntity,
+  Voter as VoterEntity,
 } from '../generated/schema'
 
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
 export function handleStartVote(event: StartVoteEvent): void {
-  let vote = _getVoteEntity(event.address, event.params.voteId)
+  const voteEntityId = buildVoteEntityId(event.address, event.params.voteId)
+  const vote = new VoteEntity(voteEntityId)
+  const voting = VotingContract.bind(event.address)
+  const voteData = voting.getVote(event.params.voteId)
 
-  _populateVoteDataFromEvent(vote, event)
-  _populateVoteDataFromContract(vote, event.address, vote.voteNum)
-
-  vote.save()
-}
-
-export function handleCastVote(event: CastVoteEvent): void {
-  let vote = _getVoteEntity(event.address, event.params.voteId)
-
-  let numCasts = vote.casts.length
-
-  let castId = _getCastEntityId(vote, numCasts)
-  let cast = new CastEntity(castId)
-
-  _populateCastDataFromEvent(cast, event)
-  cast.voteNum = vote.voteNum
-  cast.voteId = vote.id
-
-  let casts = vote.casts
-  casts.push(castId)
-  vote.casts = casts
-
-  if (event.params.supports == true) {
-    vote.yea = vote.yea.plus(event.params.stake)
-  } else {
-    vote.nay = vote.nay.plus(event.params.stake)
-  }
-
-  vote.save()
-  cast.save()
-}
-
-export function handleExecuteVote(event: ExecuteVoteEvent): void {
-  let vote = _getVoteEntity(event.address, event.params.voteId)
-
-  vote.executed = true
-
-  vote.save()
-}
-
-function _getVoteEntity(appAddress: Address, voteNum: BigInt): VoteEntity {
-  let voteEntityId = _getVoteEntityId(appAddress, voteNum)
-
-  let vote = VoteEntity.load(voteEntityId)
-  if (!vote) {
-    vote = new VoteEntity(voteEntityId)
-
-    vote.voteNum = voteNum
-    vote.executed = false
-    vote.casts = []
-  }
-
-  return vote!
-}
-
-function _getCastEntityId(vote: VoteEntity, numCast: number): string {
-  return vote.id + '-castNum:' + numCast.toString()
-}
-
-function _getVoteEntityId(appAddress: Address, voteNum: BigInt): string {
-  return 'appAddress:' + appAddress.toHexString() + '-voteId:' + voteNum.toHexString()
-}
-
-function _populateVoteDataFromContract(vote: VoteEntity, appAddress: Address, voteNum: BigInt): void {
-  let voting = VotingContract.bind(appAddress)
-
-  let voteData = voting.getVote(voteNum)
-
+  vote.appAddress = event.address
+  vote.creator = event.params.creator
+  vote.metadata = event.params.metadata
+  vote.voteNum = event.params.voteId
   vote.executed = voteData.value1
   vote.startDate = voteData.value2
   vote.snapshotBlock = voteData.value3
@@ -91,16 +33,94 @@ function _populateVoteDataFromContract(vote: VoteEntity, appAddress: Address, vo
   vote.votingPower = voteData.value8
   vote.script = voteData.value9
   vote.orgAddress = voting.kernel()
-  vote.appAddress = appAddress
+  vote.executedAt = BigInt.fromI32(0)
+  vote.executed = false
+
+  vote.save()
 }
 
-function _populateVoteDataFromEvent(vote: VoteEntity, event: StartVoteEvent): void {
-  vote.creator = event.params.creator
-  vote.metadata = event.params.metadata
+export function handleCastVote(event: CastVoteEvent): void {
+  updateVoteState(event.address, event.params.voteId)
+
+  const voter = loadOrCreateVoter(event.address, event.params.voter)
+  voter.save()
+
+  const castVote = loadOrCreateCastVote(
+    event.address,
+    event.params.voteId,
+    event.params.voter
+  )
+
+  castVote.voter = voter.id
+  castVote.stake = event.params.stake
+  castVote.supports = event.params.supports
+  castVote.createdAt = event.block.timestamp
+
+  castVote.save()
 }
 
-function _populateCastDataFromEvent(cast: CastEntity, event: CastVoteEvent): void {
-  cast.voter = event.params.voter
-  cast.supports = event.params.supports
-  cast.voterStake = event.params.stake
+export function handleExecuteVote(event: ExecuteVoteEvent): void {
+  updateVoteState(event.address, event.params.voteId)
+
+  const vote = VoteEntity.load(
+    buildVoteEntityId(event.address, event.params.voteId)
+  )!
+  vote.executed = true
+  vote.executedAt = event.block.timestamp
+  vote.save()
+}
+
+function buildVoteEntityId(appAddress: Address, voteNum: BigInt): string {
+  return (
+    'appAddress:' +
+    appAddress.toHexString() +
+    '-voteId:' +
+    voteNum.toHexString()
+  )
+}
+
+function buildVoterId(voting: Address, voter: Address): string {
+  return voting.toHexString() + '-voter-' + voter.toHexString()
+}
+
+function buildCastEntityId(voteId: BigInt, voter: Address): string {
+  return voteId.toHexString() + '-voter:' + voter.toHexString()
+}
+
+function loadOrCreateVoter(
+  votingAddress: Address,
+  voterAddress: Address
+): VoterEntity {
+  const voterId = buildVoterId(votingAddress, voterAddress)
+  let voter = VoterEntity.load(voterId)
+  if (voter === null) {
+    voter = new VoterEntity(voterId)
+    voter.address = voterAddress
+  }
+  return voter!
+}
+
+function loadOrCreateCastVote(
+  votingAddress: Address,
+  voteId: BigInt,
+  voterAddress: Address
+): CastEntity {
+  const castVoteId = buildCastEntityId(voteId, voterAddress)
+  let castVote = CastEntity.load(castVoteId)
+  if (castVote === null) {
+    castVote = new CastEntity(castVoteId)
+    castVote.vote = buildVoteEntityId(votingAddress, voteId)
+  }
+  return castVote!
+}
+
+export function updateVoteState(votingAddress: Address, voteId: BigInt): void {
+  const votingApp = VotingContract.bind(votingAddress)
+  const voteData = votingApp.getVote(voteId)
+
+  const vote = VoteEntity.load(buildVoteEntityId(votingAddress, voteId))!
+  vote.yea = voteData.value6
+  vote.nay = voteData.value7
+
+  vote.save()
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/connect",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.6",
   "license": "LGPL-3.0-or-later",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -34,9 +34,9 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@aragon/connect-core": "^0.8.0-alpha.5",
-    "@aragon/connect-ethereum": "^0.8.0-alpha.5",
-    "@aragon/connect-thegraph": "^0.8.0-alpha.5"
+    "@aragon/connect-core": "^0.8.0-alpha.6",
+    "@aragon/connect-ethereum": "^0.8.0-alpha.6",
+    "@aragon/connect-thegraph": "^0.8.0-alpha.6"
   },
   "description": "Access and interact with Aragon Organizations and their apps.",
   "keywords": [


### PR DESCRIPTION
Reuse changes from https://github.com/aragon/aragon-cli/pull/1687

This fix prevents using the wrong signature hash from artifact functions by preferring creating the signature from the ABI definition.