### PR TITLE
Agreement: align the connector with the other app connectors

### DIFF
--- a/packages/connect-agreement/src/connect.ts
+++ b/packages/connect-agreement/src/connect.ts
@@ -10,7 +10,7 @@ type Config = {
 }
 
 export default createAppConnector<Agreement, Config>(
-  ({ app, config, connector, network, orgConnector, verbose }) => {
+  async ({ app, config, connector, network, orgConnector, verbose }) => {
     if (connector !== 'thegraph') {
       console.warn(
         `Connector unsupported: ${connector}. Using "thegraph" instead.`
@@ -26,7 +26,7 @@ export default createAppConnector<Agreement, Config>(
         config?.pollInterval ?? orgConnector.config?.pollInterval ?? undefined
     }
 
-    const connectorTheGraph = new AgreementConnectorTheGraph({
+    const connectorTheGraph = await AgreementConnectorTheGraph.create({
       pollInterval,
       subgraphUrl,
       verbose,

--- a/packages/connect-agreement/src/thegraph/connector.ts
+++ b/packages/connect-agreement/src/thegraph/connector.ts
@@ -1,7 +1,9 @@
 import {
+  Address,
   SubscriptionCallback,
   SubscriptionHandler,
 } from '@aragon/connect-types'
+import { ErrorException } from '@aragon/connect-core'
 import { GraphQLWrapper, QueryResult } from '@aragon/connect-thegraph'
 
 import * as queries from './queries'
@@ -44,6 +46,7 @@ export function subgraphUrlFromChainId(chainId: number) {
 }
 
 type AgreementConnectorTheGraphConfig = {
+  appAddress?: Address
   pollInterval?: number
   subgraphUrl?: string
   verbose?: boolean
@@ -52,16 +55,31 @@ type AgreementConnectorTheGraphConfig = {
 export default class AgreementConnectorTheGraph implements IAgreementConnector {
   #gql: GraphQLWrapper
 
-  constructor(config: AgreementConnectorTheGraphConfig) {
+  constructor(gql: GraphQLWrapper) {
+    this.#gql = gql
+  }
+
+  static async create(
+    config: AgreementConnectorTheGraphConfig
+  ): Promise<AgreementConnectorTheGraph> {
     if (!config.subgraphUrl) {
-      throw new Error(
+      throw new ErrorException(
         'AgreementConnectorTheGraph requires subgraphUrl to be passed.'
       )
     }
-    this.#gql = new GraphQLWrapper(config.subgraphUrl, {
+
+    if (!config.appAddress) {
+      throw new ErrorException(
+        'AgreementConnectorTheGraph requires appAddress to be passed.'
+      )
+    }
+
+    const gql = new GraphQLWrapper(config.subgraphUrl, {
       pollInterval: config.pollInterval,
       verbose: config.verbose,
     })
+
+    return new AgreementConnectorTheGraph(gql)
   }
 
   async disconnect() {
@@ -248,9 +266,7 @@ export default class AgreementConnectorTheGraph implements IAgreementConnector {
     )
   }
 
-  async staking(
-    stakingId: string
-  ): Promise<Staking> {
+  async staking(stakingId: string): Promise<Staking> {
     return this.#gql.performQueryWithParser<Staking>(
       queries.GET_STAKING('query'),
       { stakingId },
@@ -300,9 +316,7 @@ export default class AgreementConnectorTheGraph implements IAgreementConnector {
     )
   }
 
-  async action(
-    actionId: string
-  ): Promise<Action | null> {
+  async action(actionId: string): Promise<Action | null> {
     return this.#gql.performQueryWithParser<Action | null>(
       queries.GET_ACTION('query'),
       { actionId },
@@ -322,7 +336,7 @@ export default class AgreementConnectorTheGraph implements IAgreementConnector {
     )
   }
 
-  async ERC20(tokenAddress: string): Promise<ERC20> {
+  async ERC20(tokenAddress: Address): Promise<ERC20> {
     return this.#gql.performQueryWithParser<ERC20>(
       queries.GET_ERC20('query'),
       { tokenAddress },
@@ -331,7 +345,7 @@ export default class AgreementConnectorTheGraph implements IAgreementConnector {
   }
 
   onERC20(
-    tokenAddress: string,
+    tokenAddress: Address,
     callback: SubscriptionCallback<ERC20>
   ): SubscriptionHandler {
     return this.#gql.subscribeToQueryWithParser<ERC20>(

--- a/packages/connect-agreement/src/thegraph/parsers/agreement.ts
+++ b/packages/connect-agreement/src/thegraph/parsers/agreement.ts
@@ -1,12 +1,12 @@
+import { ErrorUnexpectedResult } from '@aragon/connect-core'
 import { QueryResult } from '@aragon/connect-thegraph'
-
 import { AgreementData } from '../../types'
 
 export function parseAgreement(result: QueryResult): AgreementData {
-  const agreement = result.data.agreement
+  const agreement = result.data?.agreement
 
   if (!agreement) {
-    throw new Error('Unable to parse agreement.')
+    throw new ErrorUnexpectedResult('Unable to parse agreement.')
   }
 
   return {


### PR DESCRIPTION
- Custom errors.
- Uses `AgreementConnectorTheGraph.create()` to instantiate.
- Use `Address` when possible.