### PR TITLE
Voting Connector: Support vote rewards

### DIFF
--- a/packages/connect-core/src/index.ts
+++ b/packages/connect-core/src/index.ts
@@ -22,6 +22,7 @@ export {
   ConnectionContext,
   IpfsResolver,
   AppData,
+  AppMethod,
   ForwardingPathData,
   PermissionData,
   RepoData,

--- a/packages/connect-core/src/types.ts
+++ b/packages/connect-core/src/types.ts
@@ -137,6 +137,7 @@ export type Metadata = (AragonArtifact | AragonManifest)[]
 export interface AppMethod {
   roles: string[]
   sig: string
+  params?: any[]
   /**
    * This field might not be able if the contract does not use
    * conventional solidity syntax and Aragon naming standards

--- a/packages/connect-voting/src/__test__/votes.test.ts
+++ b/packages/connect-voting/src/__test__/votes.test.ts
@@ -87,6 +87,18 @@ describe('when connecting to a voting app', () => {
         expect(vote.startDate).toEqual('1599675534')
       })
 
+      test('should have a valid endDate', () => {
+        expect(vote.endDate).toEqual('1600280334')
+      })
+
+      test('should have not be accepted', () => {
+        expect(vote.isAccepted).toBe(false)
+      })
+
+      test('should have a valid status', () => {
+        expect(vote.status).toEqual('Rejected')
+      })
+
       describe('when querying for the casts of a vote', () => {
         let casts: Cast[]
 

--- a/packages/connect-voting/src/__test__/votes.test.ts
+++ b/packages/connect-voting/src/__test__/votes.test.ts
@@ -1,4 +1,5 @@
 import { VotingConnectorTheGraph, Vote, Cast } from '../../src'
+import { VoteStatus } from '../types'
 
 const VOTING_SUBGRAPH_URL =
   'https://api.thegraph.com/subgraphs/name/aragon/aragon-voting-rinkeby-staging'
@@ -96,7 +97,7 @@ describe('when connecting to a voting app', () => {
       })
 
       test('should have a valid status', () => {
-        expect(vote.status).toEqual('Rejected')
+        expect(vote.status).toEqual(VoteStatus.Rejected)
       })
 
       describe('when querying for the casts of a vote', () => {

--- a/packages/connect-voting/src/helpers/index.ts
+++ b/packages/connect-voting/src/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './numbers'
+export * from './time'

--- a/packages/connect-voting/src/helpers/numbers.ts
+++ b/packages/connect-voting/src/helpers/numbers.ts
@@ -1,0 +1,3 @@
+import { BigNumber } from 'ethers'
+
+export const bn = (x: string | number): BigNumber => BigNumber.from(x.toString())

--- a/packages/connect-voting/src/helpers/time.ts
+++ b/packages/connect-voting/src/helpers/time.ts
@@ -1,0 +1,4 @@
+import { BigNumber } from 'ethers'
+import { bn } from './numbers'
+
+export const currentTimestampEvm = (): BigNumber => bn(Math.floor(Date.now() / 1000))

--- a/packages/connect-voting/src/models/Vote.ts
+++ b/packages/connect-voting/src/models/Vote.ts
@@ -1,6 +1,6 @@
 import { SubscriptionCallback, SubscriptionResult } from '@aragon/connect-types'
 import { subscription } from '@aragon/connect-core'
-import { IVotingConnector, VoteData } from '../types'
+import { IVotingConnector, VoteData, VoteStatus } from '../types'
 import Cast from './Cast'
 import { bn, currentTimestampEvm } from '../helpers'
 
@@ -45,18 +45,18 @@ export default class Vote {
     this.isAccepted = data.isAccepted
   }
 
-  get status(): string {
+  get status(): VoteStatus {
     const currentTimestamp = currentTimestampEvm()
 
     if (!this.executed) {
       if (currentTimestamp.gte(bn(this.endDate))) {
-        return this.isAccepted ? "Accepted" : "Rejected"
+        return this.isAccepted ? VoteStatus.Accepted : VoteStatus.Rejected
       }
       
-      return "Ongoing"
+      return VoteStatus.Ongoing
     }
 
-    return "Executed"
+    return VoteStatus.Executed
   }
 
   async casts({ first = 1000, skip = 0 } = {}): Promise<Cast[]> {

--- a/packages/connect-voting/src/thegraph/queries/index.ts
+++ b/packages/connect-voting/src/thegraph/queries/index.ts
@@ -14,12 +14,14 @@ export const ALL_VOTES = (type: string) => gql`
       executed
       executedAt
       startDate
+      endDate
       snapshotBlock
       supportRequiredPct
       minAcceptQuorum
       yea
       nay
       votingPower
+      isAccepted
       script
     }
   }
@@ -39,12 +41,14 @@ export const CASTS_FOR_VOTE = (type: string) => gql`
         executed
         executedAt
         startDate
+        endDate
         snapshotBlock
         supportRequiredPct
         minAcceptQuorum
         yea
         nay
         votingPower
+        isAccepted
         script
       }
       voter {

--- a/packages/connect-voting/src/types.ts
+++ b/packages/connect-voting/src/types.ts
@@ -13,6 +13,7 @@ export interface VoteData {
   executed: boolean
   executedAt: string
   startDate: string
+  endDate: string
   snapshotBlock: string
   supportRequiredPct: string
   minAcceptQuorum: string
@@ -20,6 +21,7 @@ export interface VoteData {
   nay: string
   votingPower: string
   script: string
+  isAccepted: boolean
 }
 
 export interface CastData {

--- a/packages/connect-voting/src/types.ts
+++ b/packages/connect-voting/src/types.ts
@@ -5,6 +5,13 @@ import {
 import Vote from './models/Vote'
 import Cast from './models/Cast'
 
+export enum VoteStatus {
+  Accepted = "Accepted",
+  Executed = "Executed",
+  Ongoing = "Ongoing",
+  Rejected = "Rejected",
+}
+
 export interface VoteData {
   id: string
   creator: string

--- a/packages/connect-voting/subgraph/schema.graphql
+++ b/packages/connect-voting/subgraph/schema.graphql
@@ -8,6 +8,7 @@ type Vote @entity {
   executed: Boolean!
   executedAt: BigInt!
   startDate: BigInt!
+  endDate: BigInt!
   snapshotBlock: BigInt!
   supportRequiredPct: BigInt!
   minAcceptQuorum: BigInt!

--- a/packages/connect-voting/subgraph/schema.graphql
+++ b/packages/connect-voting/subgraph/schema.graphql
@@ -16,6 +16,7 @@ type Vote @entity {
   votingPower: BigInt!
   script: String!
   voteNum: BigInt!
+  isAccepted: Boolean!
   castVotes: [Cast!] @derivedFrom(field: "vote")
 }
 

--- a/packages/connect-voting/subgraph/src/Voting.ts
+++ b/packages/connect-voting/subgraph/src/Voting.ts
@@ -25,6 +25,7 @@ export function handleStartVote(event: StartVoteEvent): void {
   vote.metadata = event.params.metadata
   vote.voteNum = event.params.voteId
   vote.startDate = voteData.value2
+  vote.endDate = vote.startDate.plus(voting.voteTime())
   vote.snapshotBlock = voteData.value3
   vote.supportRequiredPct = voteData.value4
   vote.minAcceptQuorum = voteData.value5
@@ -36,7 +37,6 @@ export function handleStartVote(event: StartVoteEvent): void {
   vote.executedAt = BigInt.fromI32(0)
   vote.executed = false
   vote.isAccepted = isAccepted(vote.yea, vote.nay, vote.votingPower, vote.supportRequiredPct, vote.minAcceptQuorum, voting.PCT_BASE())
-
   vote.save()
 }
 

--- a/packages/connect-voting/subgraph/src/Voting.ts
+++ b/packages/connect-voting/subgraph/src/Voting.ts
@@ -35,6 +35,7 @@ export function handleStartVote(event: StartVoteEvent): void {
   vote.orgAddress = voting.kernel()
   vote.executedAt = BigInt.fromI32(0)
   vote.executed = false
+  vote.isAccepted = isAccepted(vote.yea, vote.nay, vote.votingPower, vote.supportRequiredPct, vote.minAcceptQuorum, voting.PCT_BASE())
 
   vote.save()
 }
@@ -118,6 +119,16 @@ export function updateVoteState(votingAddress: Address, voteId: BigInt): void {
   const vote = VoteEntity.load(buildVoteEntityId(votingAddress, voteId))!
   vote.yea = voteData.value6
   vote.nay = voteData.value7
+  vote.isAccepted = isAccepted(vote.yea, vote.nay, vote.votingPower, vote.supportRequiredPct, vote.minAcceptQuorum, votingApp.PCT_BASE())
 
   vote.save()
+}
+
+function isAccepted(yeas: BigInt, nays: BigInt, votingPower: BigInt, supportRequiredPct: BigInt, minimumAcceptanceQuorumPct: BigInt, pctBase: BigInt): boolean {
+  return hasReachedValuePct(yeas, yeas.plus(nays), supportRequiredPct, pctBase) &&
+         hasReachedValuePct(yeas, votingPower, minimumAcceptanceQuorumPct, pctBase)
+}
+
+function hasReachedValuePct(value: BigInt, total: BigInt, pct: BigInt, pctBase: BigInt): boolean {
+  return total.notEqual(BigInt.fromI32(0)) && (value.times(pctBase).div(total)).gt(pct)
 }


### PR DESCRIPTION
This PR builds on top of #336 and addreses the [DeepDao's Gitcoin bounty](https://gitcoin.co/issue/deepdao1/global-dao-hackaton-10.2021/3/100026940) related to supporting vote rewards.

It adds a new functionality to the `Vote` model that allows you to get all the actions inside the vote  `script` which is a set of codified DAO's app contract calls that are executed once the vote is enacted.

If an action involves a token transfer from the DAO to an external account then a `rewards` field is filled.

The following are considered to be  token transfer actions:

- Calls to the Vault/Agent's `transfer(address _token, address _to, uint256 _value)` function
- Calls to the Finance's `newImmediatePayment(address _token, address _receiver, uint256 _amount, string _reference)`